### PR TITLE
Multi gpu training

### DIFF
--- a/examples/qm9_utils.py
+++ b/examples/qm9_utils.py
@@ -89,16 +89,19 @@ def set_seed(seed: int) -> None:
     dgl_seed(seed)
 
 
-def create_dataloaders(config: Munch, data: tuple):
+def create_dataloaders(config: Munch, data: tuple, use_ddp=False):
     dataloaders = namedtuple("Dataloaders", ["train", "val", "test"])
 
     dataloaders.train = GraphDataLoader(
         data.train,
         pin_memory=False,
+        use_ddp=use_ddp,
         batch_size=config.data.batch_size
         # **config.experiment.train,
     )
-    dataloaders.val = GraphDataLoader(data.val)  # , **config.experiment.val)
+    dataloaders.val = GraphDataLoader(data.val,
+                    use_ddp=use_ddp,
+    )  # , **config.experiment.val)
     dataloaders.test = GraphDataLoader(data.test)  # , **config.experiment.test)
 
     return dataloaders

--- a/examples/train.py
+++ b/examples/train.py
@@ -202,8 +202,5 @@ if __name__ == "__main__":
 
     args = argparser.parse_args()
     set_seed(args.seed)
-#    config = prepare_config(f'./configs/{args.config_name}.yaml')
-#    data = prepare_data(config)
     print(args)
     mp.spawn(run, args=[args], nprocs=args.n_gpus)
-#    mp.spawn(run, args=(args, config, data), nprocs=args.n_gpus)


### PR DESCRIPTION
Multiple GPU training of megnet with QM9 data.

Training 1000 epochs with 1, 2, 4 GPUs consumed 43.80 (100%), 22.85 (52%) and 12.51 (29%) hours. While training requires more epochs to converge with multiple GPUs, the convergence of train mse_loss is faster with more GPUs, and validation l1_loss also is converging faster with more GPUs.

Also, though training with 1 GPU converges the fastest with respect to training error, its validation loss turns out to be highest. I'm not sure about the reason, and maybe the randomness in training process is also critical, and we may need to train multiple models and select the best one from them. 

![megnet-QM9](https://user-images.githubusercontent.com/54908836/212473875-1bab3a38-9126-4b83-be33-ec8b69d24098.png)

@shyuep The current train.py is still process oriented, and the functions in QM9_train.py are not implemented in the module. Do you have any suggestions on where to put those functions and where to have a trainer class? Thanks.