### PR TITLE
Adapt potential lightning module to include optional site wise

### DIFF
--- a/matgl/apps/pes.py
+++ b/matgl/apps/pes.py
@@ -29,6 +29,7 @@ class Potential(nn.Module, IOMixIn):
         calc_forces: bool = True,
         calc_stresses: bool = True,
         calc_hessian: bool = False,
+        calc_site_wise: bool = False,
     ):
         """Initialize Potential from a model and elemental references.
 
@@ -40,6 +41,7 @@ class Potential(nn.Module, IOMixIn):
             calc_forces: Enable force calculations.
             calc_stresses: Enable stress calculations.
             calc_hessian: Enable hessian calculations.
+            calc_site_wise: Enable site-wise property calculation.
         """
         super().__init__()
         self.save_args(locals())
@@ -47,6 +49,7 @@ class Potential(nn.Module, IOMixIn):
         self.calc_forces = calc_forces
         self.calc_stresses = calc_stresses
         self.calc_hessian = calc_hessian
+        self.calc_site_wise = calc_site_wise
         self.element_refs: AtomRef | None
         if element_refs is not None:
             self.element_refs = AtomRef(property_offset=element_refs)
@@ -126,7 +129,7 @@ class Potential(nn.Module, IOMixIn):
                 count_node = count_node + num_nodes
             stresses = torch.cat(sts)
 
-        if site_wise is not None:
+        if self.calc_site_wise:
             return total_energies, forces, stresses, hessian, site_wise
 
         return total_energies, forces, stresses, hessian

--- a/matgl/utils/training.py
+++ b/matgl/utils/training.py
@@ -102,7 +102,9 @@ class MatglLightningModuleMixin:
             )
         else:
             scheduler = self.scheduler
-        return [optimizer,], [
+        return [
+            optimizer,
+        ], [
             scheduler,
         ]
 

--- a/matgl/utils/training.py
+++ b/matgl/utils/training.py
@@ -343,17 +343,20 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
         Returns:
             results, batch_size
         """
+        preds: tuple
+        labels: tuple
+
         torch.set_grad_enabled(True)
         if self.model.calc_site_wise:
             g, l_g, state_attr, energies, forces, stresses, site_wise = batch
             e, f, s, _, m = self(g=g, state_attr=state_attr, l_g=l_g)
-            preds: tuple = (e, f, s, m)
-            labels: tuple = (energies, forces, stresses, site_wise)
+            preds = (e, f, s, m)
+            labels = (energies, forces, stresses, site_wise)
         else:
             g, l_g, state_attr, energies, forces, stresses = batch
             e, f, s, _ = self(g=g, state_attr=state_attr, l_g=l_g)
-            preds: tuple = (e, f, s)
-            labels: tuple = (energies, forces, stresses)
+            preds = (e, f, s)
+            labels = (energies, forces, stresses)
 
         num_atoms = g.batch_num_nodes()
         results = self.loss_fn(


### PR DESCRIPTION
Similar to #125 in the `PotentialLightningModule`

* added an explicit `calc_site_wise` kwarg in `Potential` to match other predictions.
* the returned dictionary now has more entries, I don't think that should break backwards compat but let me know.
* calculation of site-wise is inferred based on whether site_wise_weight is passed. The same could be done for stress.

Please let me know any suggestions