### PR TITLE
use register buffer in Potential in LightningPotential and PES

### DIFF
--- a/matgl/apps/pes.py
+++ b/matgl/apps/pes.py
@@ -56,8 +56,10 @@ class Potential(nn.Module, IOMixIn):
         else:
             self.element_refs = None
 
-        self.data_mean = torch.tensor(data_mean) if data_mean is not None else torch.zeros(1)
-        self.data_std = torch.tensor(data_std) if data_std is not None else torch.ones(1)
+        data_mean = torch.tensor(data_mean) if data_mean is not None else torch.zeros(1)
+        data_std = torch.tensor(data_std) if data_std is not None else torch.ones(1)
+        self.register_buffer("data_mean", data_mean)
+        self.register_buffer("data_std", data_std)
 
     def forward(
         self, g: dgl.DGLGraph, state_attr: torch.Tensor | None = None, l_g: dgl.DGLGraph | None = None
@@ -73,9 +75,6 @@ class Potential(nn.Module, IOMixIn):
         if self.calc_forces:
             g.ndata["pos"].requires_grad_(True)
 
-        self.model = self.model.to(g.device)
-        self.data_mean = self.data_mean.to(g.device)
-        self.data_std = self.data_std.to(g.device)
         predictions = self.model(g, state_attr, l_g)
         if isinstance(predictions, tuple) and len(predictions) > 1:
             total_energies, site_wise = predictions


### PR DESCRIPTION
My understanding from their docs is that pytorch lightning recommends using `register_buffer` for tensors that are model attributes that are not optimized, and that calls of `to(device)` should be avoided since the lightning module "knows what device it is on".

I have checked that using register_buffer works for training on GPU successfully, but I am not an expert on this so please have a look.

https://lightning.ai/docs/pytorch/stable/accelerators/accelerator_prepare.html