### PR TITLE
Add some missing type hints to `Relaxer.relax`

### DIFF
--- a/matgl/ext/ase.py
+++ b/matgl/ext/ase.py
@@ -205,19 +205,19 @@ class Relaxer:
 
     def relax(
         self,
-        atoms: Atoms,
+        atoms: Atoms | Structure | Molecule,
         fmax: float = 0.1,
         steps: int = 500,
         traj_file: str | None = None,
-        interval=1,
-        verbose=False,
+        interval: int =1,
+        verbose: bool =False,
         **kwargs,
     ):
         """
         Relax an input Atoms.
 
         Args:
-            atoms (Atoms): the atoms for relaxation
+            atoms (Atoms | Structure | Molecule): the atoms for relaxation
             fmax (float): total force tolerance for relaxation convergence.
             Here fmax is a sum of force and stress forces
             steps (int): max number of steps for relaxation

--- a/matgl/ext/ase.py
+++ b/matgl/ext/ase.py
@@ -209,8 +209,8 @@ class Relaxer:
         fmax: float = 0.1,
         steps: int = 500,
         traj_file: str | None = None,
-        interval: int =1,
-        verbose: bool =False,
+        interval: int = 1,
+        verbose: bool = False,
         **kwargs,
     ):
         """


### PR DESCRIPTION
Pretty self-explanatory. 👍 