### PR TITLE
AtomRef Updates

### DIFF
--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dgl
-import numpy as np
 import torch
 from torch import nn
 import matgl

--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import dgl
 import torch
 from torch import nn
@@ -20,10 +21,10 @@ class AtomRef(nn.Module):
         super().__init__()
         if property_offset is None:
             property_offset = torch.zeros(max_z, dtype=matgl.float_th)
-        else:
-            max_z = property_offset.shape[-1]
+        elif isinstance(property_offset, np.ndarray | list):  # for backward compatibility of saved models
+            property_offset = torch.tensor(property_offset, dtype=matgl.float_th)
 
-        self.max_z = max_z
+        self.max_z = property_offset.shape[-1]
         self.register_buffer("property_offset", property_offset)
         self.register_buffer("onehot", torch.eye(max_z))
 

--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -26,7 +26,7 @@ class AtomRef(nn.Module):
 
         self.max_z = property_offset.shape[-1]
         self.register_buffer("property_offset", property_offset)
-        self.register_buffer("onehot", torch.eye(max_z))
+        self.register_buffer("onehot", torch.eye(self.max_z))
 
     def get_feature_matrix(self, graphs: list[dgl.DGLGraph]) -> torch.Tensor:
         """Get the number of atoms for different elements in the structure.

--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -27,8 +27,8 @@ class AtomRef(nn.Module):
         else:
             max_z = property_offset.shape[-1]
 
-        self.property_offset = property_offset
         self.max_z = max_z
+        self.register_buffer("property_offset", property_offset)
         self.register_buffer("onehot", torch.eye(max_z))
 
     def get_feature_matrix(self, graphs: list[dgl.DGLGraph]) -> torch.Tensor:

--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -54,7 +54,7 @@ class AtomRef(nn.Module):
             properties (torch.Tensor): tensor of extensive properties
         """
         features = self.get_feature_matrix(graphs)
-        self.property_offset = (torch.pinverse(features.T @ features) @ features.T) @ properties
+        self.property_offset = torch.linalg.lstsq(features, properties).solution
 
     def forward(self, g: dgl.DGLGraph, state_attr: torch.Tensor | None = None):
         """Get the total property offset for a system.

--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import numpy as np
 import dgl
+import numpy as np
 import torch
 from torch import nn
 

--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -26,9 +26,10 @@ class AtomRef(nn.Module):
             property_offset = torch.zeros(max_z, dtype=matgl.float_th)
         else:
             property_offset = torch.tensor(property_offset)
-            max_z = property_offset.size(dim=0)
+            max_z = property_offset.shape[-1]
 
         self.property_offset = property_offset
+        self.onehot = torch.eye(max_z)
         self.max_z = max_z
 
     def get_feature_matrix(self, graphs: list[dgl.DGLGraph]) -> torch.Tensor:
@@ -69,7 +70,7 @@ class AtomRef(nn.Module):
         num_elements = (
             self.property_offset.size(dim=1) if self.property_offset.ndim > 1 else self.property_offset.size(dim=0)
         )
-        one_hot = torch.eye(num_elements)[g.ndata["node_type"]]
+        one_hot = self.onehot[g.ndata["node_type"]]
         if self.property_offset.ndim > 1:
             offset_batched_with_state = []
             for i in range(self.property_offset.size(dim=0)):

--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -12,14 +12,14 @@ class AtomRef(nn.Module):
 
     def __init__(
         self,
-        max_z: int = 89,
         property_offset: torch.Tensor | None = None,
+        max_z: int = 89
     ) -> None:
         """
         Args:
-            max_z (int): maximum atomic number
             property_offset (Tensor): a tensor containing the property offset for each element
                 if given max_z is ignored, and the size of the tensor is used instead
+            max_z (int): maximum atomic number
         """
         super().__init__()
         if property_offset is None:

--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -21,7 +21,7 @@ class AtomRef(nn.Module):
         super().__init__()
         if property_offset is None:
             property_offset = torch.zeros(max_z, dtype=matgl.float_th)
-        elif isinstance(property_offset, np.ndarray | list):  # for backward compatibility of saved models
+        elif isinstance(property_offset, (np.ndarray, list)):  # for backward compatibility of saved models
             property_offset = torch.tensor(property_offset, dtype=matgl.float_th)
 
         self.max_z = property_offset.shape[-1]

--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -28,8 +28,8 @@ class AtomRef(nn.Module):
             max_z = property_offset.shape[-1]
 
         self.property_offset = property_offset
-        self.onehot = torch.eye(max_z)
         self.max_z = max_z
+        self.register_buffer("onehot", torch.eye(max_z))
 
     def get_feature_matrix(self, graphs: list[dgl.DGLGraph]) -> torch.Tensor:
         """Get the number of atoms for different elements in the structure.

--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -25,7 +25,6 @@ class AtomRef(nn.Module):
         if property_offset is None:
             property_offset = torch.zeros(max_z, dtype=matgl.float_th)
         else:
-            property_offset = torch.tensor(property_offset)
             max_z = property_offset.shape[-1]
 
         self.property_offset = property_offset
@@ -67,9 +66,6 @@ class AtomRef(nn.Module):
         Returns:
             offset_per_graph
         """
-        num_elements = (
-            self.property_offset.size(dim=1) if self.property_offset.ndim > 1 else self.property_offset.size(dim=0)
-        )
         one_hot = self.onehot[g.ndata["node_type"]]
         if self.property_offset.ndim > 1:
             offset_batched_with_state = []

--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -3,22 +3,19 @@ from __future__ import annotations
 import dgl
 import torch
 from torch import nn
+
 import matgl
 
 
 class AtomRef(nn.Module):
     """Get total property offset for a system."""
 
-    def __init__(
-        self,
-        property_offset: torch.Tensor | None = None,
-        max_z: int = 89
-    ) -> None:
+    def __init__(self, property_offset: torch.Tensor | None = None, max_z: int = 89) -> None:
         """
         Args:
             property_offset (Tensor): a tensor containing the property offset for each element
                 if given max_z is ignored, and the size of the tensor is used instead
-            max_z (int): maximum atomic number
+            max_z (int): maximum atomic number.
         """
         super().__init__()
         if property_offset is None:

--- a/matgl/utils/io.py
+++ b/matgl/utils/io.py
@@ -126,7 +126,7 @@ class IOMixIn:
                 d[k] = cls_(**v["init_args"])
         d = {k: v for k, v in d.items() if not k.startswith("@")}
         model = cls(**d)
-        model.load_state_dict(state)  # type: ignore
+        model.load_state_dict(state, strict=False)  # type: ignore
 
         return model
 
@@ -213,7 +213,7 @@ def load_model(path: Path, **kwargs):
         raise ValueError(
             "Bad serialized model or bad model name. It is possible that you have an older model cached. Please "
             'clear your cache by running `python -c "import matgl; matgl.clear_cache()"`'
-        ) from None
+        )
 
 
 def _get_file_paths(path: Path, **kwargs):

--- a/matgl/utils/io.py
+++ b/matgl/utils/io.py
@@ -209,11 +209,11 @@ def load_model(path: Path, **kwargs):
             mod = __import__(modname, globals(), locals(), [classname], 0)
             cls_ = getattr(mod, classname)
             return cls_.load(fpaths, **kwargs)
-    except BaseException:
+    except BaseException as err:
         raise ValueError(
             "Bad serialized model or bad model name. It is possible that you have an older model cached. Please "
             'clear your cache by running `python -c "import matgl; matgl.clear_cache()"`'
-        )
+        ) from err
 
 
 def _get_file_paths(path: Path, **kwargs):

--- a/tests/layers/test_atom_ref.py
+++ b/tests/layers/test_atom_ref.py
@@ -10,14 +10,14 @@ from matgl.layers._atom_ref import AtomRef
 class TestAtomRef:
     def test_atom_ref(self, graph_MoSH):
         _, g1, _ = graph_MoSH
-        element_ref = AtomRef(np.array([0.5, 1.0, 2.0]))
+        element_ref = AtomRef(torch.tensor([0.5, 1.0, 2.0]))
 
         atom_ref = element_ref(g1)
         assert atom_ref == 3.5
 
     def test_atom_ref_fit(self, graph_MoSH):
         _, g1, _ = graph_MoSH
-        element_ref = AtomRef(np.array([0.5, 1.0, 2.0]))
+        element_ref = AtomRef(torch.tensor([0.5, 1.0, 2.0]))
         properties = torch.tensor([2.0, 2.0])
         bg = dgl.batch([g1, g1])
         element_ref.fit([g1, g1], properties)
@@ -26,7 +26,7 @@ class TestAtomRef:
 
     def test_atom_ref_with_states(self, graph_MoSH):
         _, g1, _ = graph_MoSH
-        element_ref = AtomRef(np.array([[0.5, 1.0, 2.0], [2.0, 3.0, 5.0]]))
+        element_ref = AtomRef(torch.tensor([[0.5, 1.0, 2.0], [2.0, 3.0, 5.0]]))
         state_label = torch.tensor([1])
         atom_ref = element_ref(g1, state_label)
         assert atom_ref == 10

--- a/tests/layers/test_atom_ref.py
+++ b/tests/layers/test_atom_ref.py
@@ -21,7 +21,7 @@ class TestAtomRef:
         properties = torch.tensor([2.0, 2.0])
         bg = dgl.batch([g1, g1])
         element_ref.fit([g1, g1], properties)
-        print(element_ref.property_offset)
+
         atom_ref = element_ref(bg)
         assert list(np.round(atom_ref.numpy())) == [2.0, 2.0]
 

--- a/tests/layers/test_atom_ref.py
+++ b/tests/layers/test_atom_ref.py
@@ -21,6 +21,7 @@ class TestAtomRef:
         properties = torch.tensor([2.0, 2.0])
         bg = dgl.batch([g1, g1])
         element_ref.fit([g1, g1], properties)
+        print(element_ref.property_offset)
         atom_ref = element_ref(bg)
         assert list(np.round(atom_ref.numpy())) == [2.0, 2.0]
 


### PR DESCRIPTION
A few edits to the `AtomRef` class:

* added `max_z` as optional kwarg for cases where offsets have not been fitted yet.
* Removed all use of `numpy`
* Use `lstsq` instead of explicitly pseudo-inverse
* Made `property_offset` a buffer to avoid errors when running on GPU and with lightning modules
* Save precomputed identity matrix for onehot vectors as buffer.