### PR TITLE
Allow for a catch-all bin for atom types during graph construction

### DIFF
--- a/matgl/ext/pymatgen.py
+++ b/matgl/ext/pymatgen.py
@@ -37,15 +37,21 @@ class Molecule2Graph(GraphConverter):
         self,
         element_types: tuple[str, ...],
         cutoff: float = 5.0,
+        allow_other_atoms: bool = False,
     ):
         """Parameters
         ----------
         element_types: List of elements present in dataset for graph conversion. This ensures all graphs are
             constructed with the same dimensionality of features.
         cutoff: Cutoff radius for graph representation
+        allow_other_atoms: if an atom found in a provided structure is not found
+            in the element_types list, it will be provided the index len(element_types),
+            a "catch all" bin for all other elements
         """
+
         self.element_types = tuple(element_types)
         self.cutoff = cutoff
+        self.allow_other_atoms = allow_other_atoms
 
     def get_graph(self, mol: Molecule) -> tuple[dgl.DGLGraph, list]:
         """Get a DGL graph from an input molecule.
@@ -71,6 +77,7 @@ class Molecule2Graph(GraphConverter):
             lattice_matrix=np.zeros((1, 3, 3)),
             element_types=element_types,
             cart_coords=R,
+            allow_other_atoms=self.allow_other_atoms,
         )
         state_attr = [weight, nbonds]
         return g, state_attr
@@ -83,15 +90,21 @@ class Structure2Graph(GraphConverter):
         self,
         element_types: tuple[str, ...],
         cutoff: float = 5.0,
+        allow_other_atoms: bool = False,
     ):
         """Parameters
         ----------
         element_types: List of elements present in dataset for graph conversion. This ensures all graphs are
             constructed with the same dimensionality of features.
         cutoff: Cutoff radius for graph representation
+        allow_other_atoms: if an atom found in a provided structure is not found
+            in the element_types list, it will be provided the index len(element_types),
+            a "catch all" bin for all other elements
         """
+
         self.element_types = tuple(element_types)
         self.cutoff = cutoff
+        self.allow_other_atoms = allow_other_atoms
 
     def get_graph(self, structure: Structure) -> tuple[dgl.DGLGraph, list]:
         """Get a DGL graph from an input Structure.
@@ -130,6 +143,7 @@ class Structure2Graph(GraphConverter):
             [lattice_matrix],
             element_types,
             cart_coords,
+            allow_other_atoms=self.allow_other_atoms,
         )
         g.ndata["volume"] = torch.tensor([volume] * g.num_nodes())
         return g, state_attr

--- a/matgl/ext/pymatgen.py
+++ b/matgl/ext/pymatgen.py
@@ -48,7 +48,6 @@ class Molecule2Graph(GraphConverter):
             in the element_types list, it will be provided the index len(element_types),
             a "catch all" bin for all other elements
         """
-
         self.element_types = tuple(element_types)
         self.cutoff = cutoff
         self.allow_other_atoms = allow_other_atoms
@@ -101,7 +100,6 @@ class Structure2Graph(GraphConverter):
             in the element_types list, it will be provided the index len(element_types),
             a "catch all" bin for all other elements
         """
-
         self.element_types = tuple(element_types)
         self.cutoff = cutoff
         self.allow_other_atoms = allow_other_atoms

--- a/matgl/graph/converters.py
+++ b/matgl/graph/converters.py
@@ -29,7 +29,6 @@ class GraphConverter(metaclass=abc.ABCMeta):
         in the provided list, len(element_types) will be returned (this is an
         extra "catch all" index for any element not found in the list).
         """
-
         try:
             return element_types.index(site.specie.symbol)
         except ValueError:
@@ -39,14 +38,13 @@ class GraphConverter(metaclass=abc.ABCMeta):
                 "allow_other_atoms is False and atom type "
                 f"{site.specie.symbol} was not found in the element types "
                 f"list {element_types}"
-            )
+            ) from None
 
     @staticmethod
     def _index_ase(element_to_index, elem, allow_other_atoms):
         """See _index above (this does the same thing, basically, except it
         deals with a dictionary instead of a list).
         """
-
         try:
             return element_to_index[elem]
         except KeyError:
@@ -56,7 +54,7 @@ class GraphConverter(metaclass=abc.ABCMeta):
                 "allow_other_atoms is False and atom type "
                 f"{elem} was not found in the element types "
                 f"list {element_to_index}"
-            )
+            ) from None
 
     def get_graph_from_processed_structure(
         self,

--- a/matgl/graph/converters.py
+++ b/matgl/graph/converters.py
@@ -22,6 +22,42 @@ class GraphConverter(metaclass=abc.ABCMeta):
         DGLGraph object, state_attr
         """
 
+    @staticmethod
+    def _index(element_types, site, allow_other_atoms):
+        """Returns the index of the provided Pymatgen site in the list of
+        element types. If allow_other_atoms is True, and the site is not found
+        in the provided list, len(element_types) will be returned (this is an
+        extra "catch all" index for any element not found in the list).
+        """
+
+        try:
+            return element_types.index(site.specie.symbol)
+        except ValueError:
+            if allow_other_atoms:
+                return len(element_types)
+            raise ValueError(
+                "allow_other_atoms is False and atom type "
+                f"{site.specie.symbol} was not found in the element types "
+                f"list {element_types}"
+            )
+
+    @staticmethod
+    def _index_ase(element_to_index, elem, allow_other_atoms):
+        """See _index above (this does the same thing, basically, except it
+        deals with a dictionary instead of a list).
+        """
+
+        try:
+            return element_to_index[elem]
+        except KeyError:
+            if allow_other_atoms:
+                return len(element_to_index)
+            raise KeyError(
+                "allow_other_atoms is False and atom type "
+                f"{elem} was not found in the element types "
+                f"list {element_to_index}"
+            )
+
     def get_graph_from_processed_structure(
         self,
         structure,
@@ -32,6 +68,7 @@ class GraphConverter(metaclass=abc.ABCMeta):
         element_types,
         cart_coords,
         is_atoms: bool = False,
+        allow_other_atoms: bool = False,
     ) -> tuple[dgl.DGLGraph, list]:
         """Construct a dgl graph from processed structure and bond information.
 
@@ -44,6 +81,9 @@ class GraphConverter(metaclass=abc.ABCMeta):
             element_types: Element symbols of all atoms in the structure.
             cart_coords: Cartisian coordinates of all atoms in the structure.
             is_atoms: whether the input structure object is ASE atoms object or not.
+            allow_other_atoms: if an atom found in a provided structure is not found
+                in the element_types list, it will be provided the index len(element_types),
+                a "catch all" bin for all other elements
 
         Returns:
             DGLGraph object, state_attr
@@ -56,12 +96,21 @@ class GraphConverter(metaclass=abc.ABCMeta):
         # Note: pbc_ offshift and pos needs to be float64 to handle cases where bonds are exactly at cutoff
         g.edata["pbc_offshift"] = torch.matmul(pbc_offset, torch.tensor(lattice_matrix[0]))
         g.edata["lattice"] = torch.tensor(np.repeat(lattice_matrix, g.num_edges(), axis=0), dtype=matgl.float_th)
-        element_to_index = {elem: idx for idx, elem in enumerate(element_types)}
-        node_type = (
-            np.array([element_types.index(site.specie.symbol) for site in structure])
-            if is_atoms is False
-            else np.array([element_to_index[elem] for elem in structure.get_chemical_symbols()])
-        )
+
+        # Not an ASE atoms object
+        if not is_atoms:
+            node_type = np.array([self._index(element_types, site, allow_other_atoms) for site in structure])
+
+        # Is an ASE atoms object
+        else:
+            element_to_index = {elem: idx for idx, elem in enumerate(element_types)}
+            node_type = np.array(
+                [
+                    self._index_ase(element_to_index, elem, allow_other_atoms)
+                    for elem in structure.get_chemical_symbols()
+                ]
+            )
+
         g.ndata["node_type"] = torch.tensor(node_type, dtype=matgl.int_th)
         g.ndata["pos"] = torch.tensor(cart_coords, dtype=torch.float64)
         state_attr = np.array([0.0, 0.0]).astype(matgl.float_np)

--- a/tests/ext/test_pymatgen.py
+++ b/tests/ext/test_pymatgen.py
@@ -67,6 +67,40 @@ class TestPmg2Graph:
         # check the volume
         assert np.allclose(graph.ndata["volume"][0], [65.939264])
 
+    def test_get_graph_from_structure_allow_other_atoms(self, LiFePO4):
+        # Control
+        element_types = ["Li", "Fe", "P", "O"]
+        s2g = Structure2Graph(element_types=element_types, cutoff=4.0, allow_other_atoms=True)
+        graph, _ = s2g.get_graph(LiFePO4)
+
+        # Check that the feature length is correct
+        assert len(np.unique(graph.ndata["node_type"].detach().numpy())) == 4
+
+        # Check that they match up properly
+        assert all(
+            [
+                element_types.index(s.specie.symbol) == xx
+                for s, xx in zip(LiFePO4, graph.ndata["node_type"].detach().numpy())
+            ]
+        )
+
+        element_types = ["Li", "Fe"]
+        s2g = Structure2Graph(element_types=element_types, cutoff=4.0, allow_other_atoms=True)
+        graph, _ = s2g.get_graph(LiFePO4)
+
+        # Check that the feature length is correct
+        features = graph.ndata["node_type"].detach().numpy()
+        assert len(np.unique(features)) == 3
+
+        # Check that they match up properly
+        for s, xx in zip(LiFePO4, features):
+            if s.specie.symbol == "Li":
+                assert xx == 0
+            elif s.specie.symbol == "Fe":
+                assert xx == 1
+            else:
+                assert xx == 2
+
     def test_get_element_list(self):
         cscl = Structure.from_spacegroup("Pm-3m", Lattice.cubic(3), ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
         naf = Structure.from_spacegroup("Pm-3m", Lattice.cubic(3), ["Na", "F"], [[0, 0, 0], [0.5, 0.5, 0.5]])

--- a/tests/ext/test_pymatgen.py
+++ b/tests/ext/test_pymatgen.py
@@ -78,10 +78,8 @@ class TestPmg2Graph:
 
         # Check that they match up properly
         assert all(
-            [
-                element_types.index(s.specie.symbol) == xx
-                for s, xx in zip(LiFePO4, graph.ndata["node_type"].detach().numpy())
-            ]
+            element_types.index(s.specie.symbol) == xx
+            for s, xx in zip(LiFePO4, graph.ndata["node_type"].detach().numpy())
         )
 
         element_types = ["Li", "Fe"]


### PR DESCRIPTION
In the construction of graphs from structures and molecules, a list of allowed elements is provided. However, if an atom is provided in a structure not found in the provided lists, a Value or KeyError is raised.

This commit allows the user to set an argument `allow_other_atoms` during instantiation of `Structure2Graph` and `Molecule2Graph`, which if True, treats any atom not found in the provided list as its own category.

For example, if `element_types=["Ti", "O"]` but a structure contains Ti, O and Mg, then Ti will be treated by index 0, O will be treated by index 1 and Mg will be treated by index `len(element_types)`, which in this case is 2.

Similarly, if a structure contains Ti, O, Mg and Fe, then both Mg and Fe will have index 2.

## Summary

Major changes:

- Modified `matgl.graph.converters.GraphConverter` to support this new feature.
- Changed the `Structure2Graph` and `Molecule2Graph` in `matgl.ext.pymatgen` to support this new feature.
- More detailed error messages for when `allow_other_atoms` is False and an atom is in a structure which is not in the list of elements provided.

## Todos

I'll probably need to write a test for this. It should be completely backwards compatible for when `allow_other_atoms` is False.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))
