### PR TITLE
Sequence instead of list for inputs

### DIFF
--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dgl
+import numpy as np
 import torch
 from torch import nn
 

--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dgl
-import numpy as np
 import torch
 from torch import nn
 

--- a/matgl/layers/_core.py
+++ b/matgl/layers/_core.py
@@ -1,13 +1,15 @@
 """Implementations of multi-layer perceptron (MLP) and other helper classes."""
 from __future__ import annotations
 
-from typing import Callable
-from collections.abc import Sequence
+from typing import TYPE_CHECKING, Callable
 
 import torch
 from dgl import DGLGraph, broadcast_edges, softmax_edges, sum_edges
 from torch import nn
 from torch.nn import LSTM, Linear, Module, ModuleList
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class MLP(nn.Module):

--- a/matgl/layers/_core.py
+++ b/matgl/layers/_core.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Callable
+from collections.abc import Sequence
 
 import torch
 from dgl import DGLGraph, broadcast_edges, softmax_edges, sum_edges
@@ -14,7 +15,7 @@ class MLP(nn.Module):
 
     def __init__(
         self,
-        dims: list[int],
+        dims: Sequence[int],
         activation: Callable[[torch.Tensor], torch.Tensor] | None = None,
         activate_last: bool = False,
         bias_last: bool = True,
@@ -93,7 +94,7 @@ class MLP(nn.Module):
 class GatedMLP(nn.Module):
     """An implementation of a Gated multi-layer perceptron."""
 
-    def __init__(self, in_feats: int, dims: list[int], activate_last: bool = True, use_bias: bool = True):
+    def __init__(self, in_feats: int, dims: Sequence[int], activate_last: bool = True, use_bias: bool = True):
         """:param in_feats: Dimension of input features.
         :param dims: Architecture of neural networks.
         :param activate_last: Whether applying activation to last layer or not.

--- a/matgl/layers/_readout.py
+++ b/matgl/layers/_readout.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
-from collections.abc import Sequence
+from typing import TYPE_CHECKING, Literal
 
 import dgl
 import torch
@@ -11,6 +10,9 @@ from dgl.nn import Set2Set
 from torch import nn
 
 from ._core import EdgeSet2Set, GatedMLP
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class Set2SetReadOut(nn.Module):

--- a/matgl/layers/_readout.py
+++ b/matgl/layers/_readout.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Literal
+from collections.abc import Sequence
 
 import dgl
 import torch
@@ -76,7 +77,7 @@ class ReduceReadOut(nn.Module):
 class WeightedReadOut(nn.Module):
     """Feed node features into Gated MLP as readout."""
 
-    def __init__(self, in_feats: int, dims: list[int], num_targets: int):
+    def __init__(self, in_feats: int, dims: Sequence[int], num_targets: int):
         """
         Args:
             in_feats: input features (nodes)


### PR DESCRIPTION
## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
