### PR TITLE
Allow to choose distribution in xavier_init

### DIFF
--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dgl
+import numpy as np
 import torch
 from torch import nn
 

--- a/matgl/layers/_atom_ref.py
+++ b/matgl/layers/_atom_ref.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dgl
-import numpy as np
 import torch
 from torch import nn
 


### PR DESCRIPTION
## Summary

* choose distribution and gain

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
