### PR TITLE
add testing to m3gnet potential training example

### DIFF
--- a/docs/tutorials/Training a M3GNet Potential with PyTorch Lightning.md
+++ b/docs/tutorials/Training a M3GNet Potential with PyTorch Lightning.md
@@ -100,7 +100,7 @@ Finally, we will initialize the Pytorch Lightning trainer and run the fitting. H
 # If you wish to disable GPU or MPS (M1 mac) training, use the accelerator="cpu" kwarg.
 logger = CSVLogger("logs", name="M3GNet_training")
 trainer = pl.Trainer(max_epochs=1, accelerator="cpu", logger=logger)
-trainer.fit(model=lit_module, train_dataloaders=train_loader, val_dataloaders=val_loader)
+trainer.fit(model=lit_module, train_dataloaders=train_loader, val_dataloaders=val_loader, inference_mode=False)
 ```
 
     GPU available: False, used: False
@@ -127,7 +127,27 @@ trainer.fit(model=lit_module, train_dataloaders=train_loader, val_dataloaders=va
 
     Epoch 0: 100%|██████████| 163/163 [00:40<00:00,  3.99it/s, v_num=1, val_Total_Loss=0.815, val_Energy_MAE=0.674, val_Force_MAE=0.289, val_Stress_MAE=0.000, val_Site_Wise_MAE=0.000, val_Energy_RMSE=0.730, val_Force_RMSE=0.419, val_Stress_RMSE=0.000, val_Site_Wise_RMSE=0.000, train_Total_Loss=21.60, train_Energy_MAE=2.500, train_Force_MAE=0.349, train_Stress_MAE=0.000, train_Site_Wise_MAE=0.000, train_Energy_RMSE=2.660, train_Force_RMSE=0.487, train_Stress_RMSE=0.000, train_Site_Wise_RMSE=0.000]
 
+```python
+# test the model, remember to set inference_mode=False in trainer (see above)
+trainer.test(dataloaders=test_loader)
+```
 
+    Restoring states from the checkpoint path at logs/M3GNet_training/version_0/checkpoints/epoch=0-step=163.ckpt
+    Loaded model weights from the checkpoint at logs/M3GNet_training/version_0/checkpoints/epoch=0-step=163.ckpt
+    Testing DataLoader 0: 100%|██████████| 21/21 [00:04<00:00,  4.25it/s]
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃        Test metric        ┃       DataLoader 0        ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │      test_Energy_MAE      │    0.39233624935150146    │
+    │     test_Energy_RMSE      │    0.47101688385009766    │
+    │      test_Force_MAE       │    0.2673814296722412     │
+    │      test_Force_RMSE      │    0.3861512243747711     │
+    │    test_Site_Wise_MAE     │            0.0            │
+    │    test_Site_Wise_RMSE    │            0.0            │
+    │      test_Stress_MAE      │            0.0            │
+    │     test_Stress_RMSE      │            0.0            │
+    │      test_Total_Loss      │     0.754666268825531     │
+    └───────────────────────────┴───────────────────────────┘
 
 ```python
 # save trained model

--- a/examples/Training a M3GNet Potential with PyTorch Lightning.ipynb
+++ b/examples/Training a M3GNet Potential with PyTorch Lightning.ipynb
@@ -17,7 +17,8 @@
    "execution_count": null,
    "id": "6355190a",
    "metadata": {
-    "id": "6355190a"
+    "id": "6355190a",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -76,24 +77,10 @@
      ]
     },
     "id": "bd0ce8a2-ec68-4160-9457-823fb9e6a35d",
-    "outputId": "2252a59c-9a70-4673-926f-9ed8fc69ed0d"
+    "outputId": "2252a59c-9a70-4673-926f-9ed8fc69ed0d",
+    "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Retrieving ThermoDoc documents: 100%|██████████| 407/407 [00:00<00:00, 4962446.88it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "407 downloaded from MP.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Obtain your API key here: https://next-gen.materialsproject.org/api\n",
     "mpr = MPRester(api_key=\"YOUR_API_KEY\")\n",
@@ -131,7 +118,8 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "e9dc84cb",
-    "outputId": "b9f93f24-0fd6-4737-a8e4-e87804cd3ad2"
+    "outputId": "b9f93f24-0fd6-4737-a8e4-e87804cd3ad2",
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -219,52 +207,10 @@
      ]
     },
     "id": "7472d071",
-    "outputId": "9d10c152-752f-4afc-8759-c5174ea446b9"
+    "outputId": "9d10c152-752f-4afc-8759-c5174ea446b9",
+    "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "GPU available: False, used: False\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "IPU available: False, using: 0 IPUs\n",
-      "HPU available: False, using: 0 HPUs\n",
-      "\n",
-      "  | Name  | Type              | Params\n",
-      "--------------------------------------------\n",
-      "0 | mae   | MeanAbsoluteError | 0     \n",
-      "1 | rmse  | MeanSquaredError  | 0     \n",
-      "2 | model | Potential         | 282 K \n",
-      "--------------------------------------------\n",
-      "282 K     Trainable params\n",
-      "0         Non-trainable params\n",
-      "282 K     Total params\n",
-      "1.130     Total estimated model params size (MB)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 0: 100%|██████████| 163/163 [00:39<00:00,  4.16it/s, v_num=1, val_Total_Loss=0.815, val_Energy_MAE=0.674, val_Force_MAE=0.289, val_Stress_MAE=0.000, val_Site_Wise_MAE=0.000, val_Energy_RMSE=0.730, val_Force_RMSE=0.419, val_Stress_RMSE=0.000, val_Site_Wise_RMSE=0.000, train_Total_Loss=21.60, train_Energy_MAE=2.500, train_Force_MAE=0.349, train_Stress_MAE=0.000, train_Site_Wise_MAE=0.000, train_Energy_RMSE=2.660, train_Force_RMSE=0.487, train_Stress_RMSE=0.000, train_Site_Wise_RMSE=0.000]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "`Trainer.fit` stopped: `max_epochs=1` reached.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 0: 100%|██████████| 163/163 [00:40<00:00,  3.99it/s, v_num=1, val_Total_Loss=0.815, val_Energy_MAE=0.674, val_Force_MAE=0.289, val_Stress_MAE=0.000, val_Site_Wise_MAE=0.000, val_Energy_RMSE=0.730, val_Force_RMSE=0.419, val_Stress_RMSE=0.000, val_Site_Wise_RMSE=0.000, train_Total_Loss=21.60, train_Energy_MAE=2.500, train_Force_MAE=0.349, train_Stress_MAE=0.000, train_Site_Wise_MAE=0.000, train_Energy_RMSE=2.660, train_Force_RMSE=0.487, train_Stress_RMSE=0.000, train_Site_Wise_RMSE=0.000]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# If you wish to disable GPU or MPS (M1 mac) training, use the accelerator=\"cpu\" kwarg.\n",
     "logger = CSVLogger(\"logs\", name=\"M3GNet_training\")\n",
@@ -276,7 +222,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9f0202f",
+   "id": "a3d971e0-1065-4b7f-a03f-06a105ce0939",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# test the model, remember to set inference_mode=False in trainer (see above)\n",
+    "trainer.test(dataloaders=test_loader)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d118b9f-a3fe-4d50-b51e-5a6d1c6dccb7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,50 +318,7 @@
     "id": "4133225a-5990-4b97-9d73-88195df87a1a",
     "outputId": "f149a68a-eef7-4726-b3a1-723525dc908f"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "GPU available: False, used: False\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "IPU available: False, using: 0 IPUs\n",
-      "HPU available: False, using: 0 HPUs\n",
-      "\n",
-      "  | Name  | Type              | Params\n",
-      "--------------------------------------------\n",
-      "0 | mae   | MeanAbsoluteError | 0     \n",
-      "1 | rmse  | MeanSquaredError  | 0     \n",
-      "2 | model | Potential         | 288 K \n",
-      "--------------------------------------------\n",
-      "288 K     Trainable params\n",
-      "0         Non-trainable params\n",
-      "288 K     Total params\n",
-      "1.153     Total estimated model params size (MB)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 0: 100%|██████████| 163/163 [00:37<00:00,  4.34it/s, v_num=1, val_Total_Loss=5.420, val_Energy_MAE=1.070, val_Force_MAE=0.407, val_Stress_MAE=0.000, val_Site_Wise_MAE=0.000, val_Energy_RMSE=1.330, val_Force_RMSE=0.615, val_Stress_RMSE=0.000, val_Site_Wise_RMSE=0.000, train_Total_Loss=21.80, train_Energy_MAE=3.270, train_Force_MAE=0.572, train_Stress_MAE=0.000, train_Site_Wise_MAE=0.000, train_Energy_RMSE=3.430, train_Force_RMSE=0.870, train_Stress_RMSE=0.000, train_Site_Wise_RMSE=0.000]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "`Trainer.fit` stopped: `max_epochs=1` reached.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 0: 100%|██████████| 163/163 [00:39<00:00,  4.17it/s, v_num=1, val_Total_Loss=5.420, val_Energy_MAE=1.070, val_Force_MAE=0.407, val_Stress_MAE=0.000, val_Site_Wise_MAE=0.000, val_Energy_RMSE=1.330, val_Force_RMSE=0.615, val_Stress_RMSE=0.000, val_Site_Wise_RMSE=0.000, train_Total_Loss=21.80, train_Energy_MAE=3.270, train_Force_MAE=0.572, train_Stress_MAE=0.000, train_Site_Wise_MAE=0.000, train_Energy_RMSE=3.430, train_Force_RMSE=0.870, train_Stress_RMSE=0.000, train_Site_Wise_RMSE=0.000]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# If you wish to disable GPU or MPS (M1 mac) training, use the accelerator=\"cpu\" kwarg.\n",
     "logger = CSVLogger(\"logs\", name=\"M3GNet_finetuning\")\n",
@@ -468,7 +384,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION


## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
