### PR TITLE
Ensure volume is positive in stress calculation

### DIFF
--- a/src/matgl/apps/pes.py
+++ b/src/matgl/apps/pes.py
@@ -131,7 +131,7 @@ class Potential(nn.Module, IOMixIn):
                     hessian[iatom] = tmp.view(-1)
 
         if self.calc_stresses:
-            volume = torch.det(lattice)
+            volume = torch.abs(torch.det(lattice))
             sts = -grads[1]
             scale = 1.0 / volume * -160.21766208
             sts = [i * j for i, j in zip(sts, scale)] if sts.dim() == 3 else [sts * scale]


### PR DESCRIPTION
Currently,
```
from pymatgen.util.testing import PymatgenTest
import matgl
from matgl.ext.ase import M3GNetCalculator
def LiFePO4():
    return PymatgenTest.get_structure("LiFePO4")
potential_m3gnet = matgl.load_model("M3GNet-MP-2021.2.8-PES")
m3gnet = M3GNetCalculator(potential=potential_m3gnet, stress_weight=1.)
print(m3gnet.get_stress(atoms = LiFePO4().apply_strain(0.1).to_ase_atoms()))
```
gives
```
array([[-2.4297804e+01,  2.0667364e-01, -1.2357983e-04],
       [ 2.0667414e-01, -2.3150066e+01,  4.2587479e-05],
       [-1.2232375e-04,  4.3453932e-05, -2.6601597e+01]], dtype=float32)

```
, which is incorrect (stress should be positive for a positive strain). This seems to be because, when calculating the stresses, volume is calculated as `volume = torch.det(lattice)`, but for the structure above, this value is negative. After correcting this error, the negation of the above matrix is obtained, while the results for other structures are unchanged.

(Right now, the structure retrieved from PymatgenTest is rather cruel, and in reality, this works fine using structures retrieved from the MP API.)