### PR TITLE
Add output_layer argument to M3GNet forward method to return intermediate layer outputs

### DIFF
--- a/src/matgl/models/_m3gnet.py
+++ b/src/matgl/models/_m3gnet.py
@@ -256,7 +256,7 @@ class M3GNet(nn.Module, IOMixIn):
                 edge_feat,
             )
             edge_feat, node_feat, state_feat = self.graph_layers[i](g, edge_feat, node_feat, state_feat)
-            if i + 1 in output_layer:
+            if f"{i + 1}" in output_layer:
                 return node_feat, edge_feat, state_feat
         g.ndata["node_feat"] = node_feat
         g.edata["edge_feat"] = edge_feat
@@ -302,4 +302,6 @@ class M3GNet(nn.Module, IOMixIn):
         g.ndata["pos"] = g.ndata["frac_coords"] @ lat[0]
         if state_feats is None:
             state_feats = torch.tensor(state_feats_default)
-        return self(g=g, state_attr=state_feats, output_layer=output_layer).detach()
+        if output_layer == "final":
+            return self(g=g, state_attr=state_feats).detach()
+        return self(g=g, state_attr=state_feats, output_layer=output_layer)

--- a/src/matgl/models/_m3gnet.py
+++ b/src/matgl/models/_m3gnet.py
@@ -179,7 +179,10 @@ class M3GNet(nn.Module, IOMixIn):
             input_feats = dim_node_embedding if field == "node_feat" else dim_edge_embedding
             if readout_type == "set2set":
                 self.readout = Set2SetReadOut(
-                    in_feats=input_feats, n_iters=niters_set2set, n_layers=nlayers_set2set, field=field
+                    in_feats=input_feats,
+                    n_iters=niters_set2set,
+                    n_layers=nlayers_set2set,
+                    field=field,
                 )
                 readout_feats = 2 * input_feats + dim_state_feats if include_state else 2 * input_feats  # type: ignore
             else:
@@ -247,7 +250,11 @@ class M3GNet(nn.Module, IOMixIn):
         fea_dict = {
             "bond_expansion": expanded_dists,
             "three_body_basis": three_body_basis,
-            "embedding": {"node_feat": node_feat, "edge_feat": edge_feat, "state_feat": state_feat},
+            "embedding": {
+                "node_feat": node_feat,
+                "edge_feat": edge_feat,
+                "state_feat": state_feat,
+            },
         }
         for i in range(self.n_blocks):
             edge_feat = self.three_body_interactions[i](
@@ -259,7 +266,11 @@ class M3GNet(nn.Module, IOMixIn):
                 edge_feat,
             )
             edge_feat, node_feat, state_feat = self.graph_layers[i](g, edge_feat, node_feat, state_feat)
-            fea_dict[f"gc_{i+1}"] = {"node_feat": node_feat, "edge_feat": edge_feat, "state_feat": state_feat}
+            fea_dict[f"gc_{i+1}"] = {
+                "node_feat": node_feat,
+                "edge_feat": edge_feat,
+                "state_feat": state_feat,
+            }
         g.ndata["node_feat"] = node_feat
         g.edata["edge_feat"] = edge_feat
         if self.is_intensive:
@@ -302,12 +313,9 @@ class M3GNet(nn.Module, IOMixIn):
             "bond_expansion",
             "embedding",
             "three_body_basis",
-            "gc_1",
-            "gc_2",
-            "gc_3",
             "readout",
             "final",
-        ]
+        ] + [f"gc_{i + 1}" for i in range(self.n_blocks)]
         if output_layers is None:
             output_layers = allowed_output_layers
         elif not isinstance(output_layers, list) or set(output_layers).difference(allowed_output_layers):

--- a/src/matgl/models/_m3gnet.py
+++ b/src/matgl/models/_m3gnet.py
@@ -290,8 +290,9 @@ class M3GNet(nn.Module, IOMixIn):
             graph_converter: Object that implements a get_graph_from_structure.
             output_layer : Name for the layer of GNN as output. Choose from "embedding", "gc_1", "gc_2", "gc_3",
                 "readout", and "final" (default).
+
         Returns:
-            output: output property
+            output: output property for a structure
         """
         if graph_converter is None:
             from matgl.ext.pymatgen import Structure2Graph

--- a/src/matgl/models/_m3gnet.py
+++ b/src/matgl/models/_m3gnet.py
@@ -261,11 +261,11 @@ class M3GNet(nn.Module, IOMixIn):
         g.ndata["node_feat"] = node_feat
         g.edata["edge_feat"] = edge_feat
         if self.is_intensive:
-            node_vec = self.readout(g)
-            vec = torch.hstack([node_vec, state_feat]) if self.include_states else node_vec  # type: ignore
+            field_vec = self.readout(g)
+            readout_vec = torch.hstack([field_vec, state_feat]) if self.include_states else field_vec  # type: ignore
             if output_layer == "readout":
-                return vec
-            output = self.final_layer(vec)
+                return readout_vec
+            output = self.final_layer(readout_vec)
             if self.task_type == "classification":
                 output = self.sigmoid(output)
         else:

--- a/src/matgl/models/_m3gnet.py
+++ b/src/matgl/models/_m3gnet.py
@@ -322,7 +322,7 @@ class M3GNet(nn.Module, IOMixIn):
             graph_converter: Object that implements a get_graph_from_structure.
             output_layer : Name for the layer of GNN as output. Choose from "embedding", "gc_1", "gc_2", "gc_3",
                 and "readout". By Default, intensive and extensive M3GNet models return outputs in the "readout"
-                and  "gc_3" layers, respectively.
+                layer and the "gc_3" layer, respectively.
 
         Returns:
             output: output M3GNet features for a structure

--- a/src/matgl/models/_m3gnet.py
+++ b/src/matgl/models/_m3gnet.py
@@ -291,7 +291,7 @@ class M3GNet(nn.Module, IOMixIn):
             output_layer : Name for the layer of GNN as output. Choose from "embedding", "gc_1", "gc_2", "gc_3",
                 "readout", and "final" (default).
         Returns:
-            output (torch.tensor): output property
+            output: output property
         """
         if graph_converter is None:
             from matgl.ext.pymatgen import Structure2Graph

--- a/src/matgl/models/_m3gnet.py
+++ b/src/matgl/models/_m3gnet.py
@@ -280,6 +280,7 @@ class M3GNet(nn.Module, IOMixIn):
         structure,
         state_feats: torch.Tensor | None = None,
         graph_converter: GraphConverter | None = None,
+        output_layer: str = "final",
     ):
         """Convenience method to directly predict property from structure.
 
@@ -287,7 +288,8 @@ class M3GNet(nn.Module, IOMixIn):
             structure: An input crystal/molecule.
             state_feats (torch.tensor): Graph attributes
             graph_converter: Object that implements a get_graph_from_structure.
-
+            output_layer : Name for the layer of GNN as output. Choose from "embedding", "gc_1", "gc_2", "gc_3",
+                "readout", and "final" (default).
         Returns:
             output (torch.tensor): output property
         """
@@ -300,4 +302,4 @@ class M3GNet(nn.Module, IOMixIn):
         g.ndata["pos"] = g.ndata["frac_coords"] @ lat[0]
         if state_feats is None:
             state_feats = torch.tensor(state_feats_default)
-        return self(g=g, state_attr=state_feats).detach()
+        return self(g=g, state_attr=state_feats, output_layer=output_layer).detach()

--- a/src/matgl/models/_m3gnet.py
+++ b/src/matgl/models/_m3gnet.py
@@ -224,7 +224,7 @@ class M3GNet(nn.Module, IOMixIn):
             state_attr: State attrs for a batch of graphs.
             l_g : DGLGraph for a batch of line graphs.
             output_layer : Name for the layer of GNN as output. Choose from "embedding", "gc_1", "gc_2", "gc_3",
-                "readout", and "final" (default).
+                "readout", and "final" (default). By default, the final layer output is returned.
 
         Returns:
             output: Output property for a batch of graphs
@@ -233,6 +233,10 @@ class M3GNet(nn.Module, IOMixIn):
         bond_vec, bond_dist = compute_pair_vector_and_distance(g)
         g.edata["bond_vec"] = bond_vec
         g.edata["bond_dist"] = bond_dist
+
+        allowed_output_layers = ["embedding", "gc_1", "gc_2", "gc_3", "readout", "final"]
+        if output_layer not in allowed_output_layers:
+            raise ValueError(f"Invalid output_layer, please use one of {allowed_output_layers}.")
 
         expanded_dists = self.bond_expansion(g.edata["bond_dist"])
         if l_g is None:
@@ -323,6 +327,9 @@ class M3GNet(nn.Module, IOMixIn):
         Returns:
             output: output M3GNet features for a structure
         """
+        if output_layer is None:
+            output_layer = "readout" if self.is_intensive else "gc_3"
+
         if graph_converter is None:
             from matgl.ext.pymatgen import Structure2Graph
 

--- a/tests/models/test_m3gnet.py
+++ b/tests/models/test_m3gnet.py
@@ -86,3 +86,4 @@ class TestM3GNet:
             else:
                 assert torch.numel(features["readout"]) == 2
             assert torch.numel(features["final"]) == 1
+            assert list(model.featurize_structure(structure, output_layers=["gc_1"]).keys()) == ["gc_1"]

--- a/tests/models/test_m3gnet.py
+++ b/tests/models/test_m3gnet.py
@@ -58,3 +58,20 @@ class TestM3GNet:
         model = M3GNet(element_types=["Mo", "S"], is_intensive=True, task_type="classification", readout_type="set2set")
         output = model(g=graph)
         assert torch.numel(output) == 1
+
+    def test_predict_structure(self, graph_MoS):
+        structure, graph, state = graph_MoS
+        model_intensive = M3GNet(element_types=["Mo", "S"], is_intensive=True)
+        model_extensive = M3GNet(is_intensive=False)
+        for model in [model_extensive, model_intensive]:
+            for output_layer in ["embedding", "gc_1", "gc_2", "gc_3"]:
+                node_fea, bond_fea, state_fea = model.predict_structure(structure, output_layer=output_layer)
+                assert torch.numel(node_fea) == 128
+                assert torch.numel(bond_fea) == 1792
+                assert state_fea is None
+            output_final = model.predict_structure(structure)
+            assert torch.numel(output_final) == 1
+        output_readout_intensive = model_intensive.predict_structure(structure, output_layer="readout")
+        assert torch.numel(output_readout_intensive) == 64
+        output_readout_extensive = model_extensive.predict_structure(structure, output_layer="readout")
+        assert torch.numel(output_readout_extensive) == 2


### PR DESCRIPTION
## Summary
In this PR, the `forward` method of M3GNet is modified so that intermediate outputs in "embedding", "gc_1", "gc_2", "gc_3", and "readout" layers can be extracted, while the "final" layer output stays as the default output. This allows the usage of M3GNet intermediate outputs as atom, bond, and structure features. Documentations and tests are provided.

Major changes:

1. Added the argument of `output_layer` into the `forward` method.
2. Added comprehensive tests for the `predict_structure` method.
3. Added the argument of `output_layer` into the `predict_structure` method.
4. Edited the variable names in the readout layer of M3GNet to be more precise. For example, the `node_vec` is renamed to `field_vec`, as this variable can either be node feature or edge feature instead of just node feature, depending on the argument `field`.

## Todos

Follow-up analysis for the effectiveness of atom features.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))