### PR TITLE
Adding Tensor Placement Calls For Ease of Training with PyTorch Lightning

### DIFF
--- a/src/matgl/apps/pes.py
+++ b/src/matgl/apps/pes.py
@@ -85,7 +85,7 @@ class Potential(nn.Module, IOMixIn):
         st = lat.new_zeros([g.batch_size, 3, 3])
         if self.calc_stresses:
             st.requires_grad_(True)
-        lattice = lat @ (torch.eye(3) + st)
+        lattice = lat @ (torch.eye(3).to(st.device) + st)
         g.edata["lattice"] = torch.repeat_interleave(lattice, g.batch_num_edges(), dim=0)
         g.edata["pbc_offshift"] = (g.edata["pbc_offset"].unsqueeze(dim=-1) * g.edata["lattice"]).sum(dim=1)
         g.ndata["pos"] = (

--- a/src/matgl/graph/compute.py
+++ b/src/matgl/graph/compute.py
@@ -205,9 +205,9 @@ def _compute_3body(g: dgl.DGLGraph):
     n_triple_s = [np.sum(n_triple_i[0:n_atoms])]
     src_id = torch.tensor(triple_bond_indices[:, 0], dtype=matgl.int_th)
     dst_id = torch.tensor(triple_bond_indices[:, 1], dtype=matgl.int_th)
-    l_g = dgl.graph((src_id, dst_id))
+    l_g = dgl.graph((src_id, dst_id)).to(g.device)
     three_body_id = torch.concatenate(l_g.edges())
-    n_triple_ij = torch.tensor(n_triple_ij, dtype=matgl.int_th)
+    n_triple_ij = torch.tensor(n_triple_ij, dtype=matgl.int_th).to(g.device)
     max_three_body_id = torch.max(three_body_id) + 1 if three_body_id.numel() > 0 else 0
     l_g.ndata["bond_dist"] = g.edata["bond_dist"][:max_three_body_id]
     l_g.ndata["bond_vec"] = g.edata["bond_vec"][:max_three_body_id]

--- a/src/matgl/graph/data.py
+++ b/src/matgl/graph/data.py
@@ -315,6 +315,7 @@ class M3GNetDataset(DGLDataset):
         if self.graph_labels is not None:
             state_attrs = torch.tensor(self.graph_labels).long()
         else:
+            state_attrs = np.array(state_attrs)
             state_attrs = torch.tensor(state_attrs)
 
         if self.clear_processed:

--- a/src/matgl/graph/data.py
+++ b/src/matgl/graph/data.py
@@ -315,7 +315,7 @@ class M3GNetDataset(DGLDataset):
         if self.graph_labels is not None:
             state_attrs = torch.tensor(self.graph_labels).long()
         else:
-            state_attrs = np.array(state_attrs)
+            # state_attrs = np.array(state_attrs)
             state_attrs = torch.tensor(state_attrs)
 
         if self.clear_processed:

--- a/src/matgl/graph/data.py
+++ b/src/matgl/graph/data.py
@@ -315,7 +315,6 @@ class M3GNetDataset(DGLDataset):
         if self.graph_labels is not None:
             state_attrs = torch.tensor(self.graph_labels).long()
         else:
-            # state_attrs = np.array(state_attrs)
             state_attrs = torch.tensor(state_attrs)
 
         if self.clear_processed:

--- a/src/matgl/layers/_basis.py
+++ b/src/matgl/layers/_basis.py
@@ -112,9 +112,11 @@ class SphericalBesselFunction(nn.Module):
         r_c = r.clone()
         r_c[r_c > self.cutoff] = self.cutoff
         roots = SPHERICAL_BESSEL_ROOTS[: self.max_l, : self.max_n]
+        roots = roots.to(r_c.device)
 
         results = []
         factor = torch.tensor(sqrt(2.0 / self.cutoff**3))
+        factor = factor.to(r_c.device)
         for i in range(self.max_l):
             root = torch.tensor(roots[i])
             func = self.funcs[i]

--- a/src/matgl/layers/_basis.py
+++ b/src/matgl/layers/_basis.py
@@ -112,7 +112,7 @@ class SphericalBesselFunction(nn.Module):
         r_c = r.clone()
         r_c[r_c > self.cutoff] = self.cutoff
         roots = SPHERICAL_BESSEL_ROOTS[: self.max_l, : self.max_n]
-        roots = roots.to(r_c.device)
+        roots = roots.to(r.device)
 
         results = []
         factor = torch.tensor(sqrt(2.0 / self.cutoff**3))

--- a/src/matgl/layers/_three_body.py
+++ b/src/matgl/layers/_three_body.py
@@ -103,6 +103,7 @@ def combine_sbf_shf(sbf, shf, max_n: int, max_l: int, use_phi: bool):
         # tf.repeat(2 * tf.range(max_l) + 1, repeats=max_n)
         block_size = 2 * torch.arange(max_l) + 1  # type: ignore
         # 2 * tf.range(max_l) + 1
+    repeats_sbf = repeats_sbf.to(sbf.device)
     expanded_sbf = torch.repeat_interleave(sbf, repeats_sbf, 1)
     expanded_shf = _block_repeat(shf, block_size=block_size, repeats=[max_n] * max_l)
     shape = max_n * max_l

--- a/src/matgl/utils/maths.py
+++ b/src/matgl/utils/maths.py
@@ -55,7 +55,7 @@ def _block_repeat(array, block_size, repeats):
     start = 0
 
     for i, b in enumerate(block_size):
-        indices.append(torch.tile(col_index[start : start + b], [repeats[i]]))
+        indices.append(torch.tile(col_index[start : start + b], [repeats[i]]).to(array.device))
         start += b
     indices = torch.cat(indices, axis=0)
     return torch.index_select(array, 1, indices)
@@ -188,6 +188,8 @@ def scatter_sum(input_tensor: torch.Tensor, segment_ids: torch.Tensor, num_segme
     else:
         size[dim] = num_segments
     output = torch.zeros(size, dtype=input_tensor.dtype)
+    output = output.to(input_tensor.device)
+    segment_ids = segment_ids.to(input_tensor.device)
     return output.scatter_add_(dim, segment_ids, input_tensor)
 
 

--- a/src/matgl/utils/maths.py
+++ b/src/matgl/utils/maths.py
@@ -53,7 +53,7 @@ def _block_repeat(array, block_size, repeats):
     col_index = torch.arange(array.size()[1])
     indices = []
     start = 0
-    
+
     for i, b in enumerate(block_size):
         indices.append(torch.tile(col_index[start : start + b], [repeats[i]]).to(array.device))
         start += b

--- a/src/matgl/utils/maths.py
+++ b/src/matgl/utils/maths.py
@@ -53,7 +53,7 @@ def _block_repeat(array, block_size, repeats):
     col_index = torch.arange(array.size()[1])
     indices = []
     start = 0
-
+    
     for i, b in enumerate(block_size):
         indices.append(torch.tile(col_index[start : start + b], [repeats[i]]).to(array.device))
         start += b


### PR DESCRIPTION
## Summary

This PR adds necessary [tensor.to()](https://pytorch.org/docs/stable/generated/torch.Tensor.to.html) calls to properly set up new tensors created during training. This is [recommended](https://lightning.ai/docs/pytorch/stable/accelerators/accelerator_prepare.html#init-tensors-using-tensor-to-and-register-buffer) by PyTorch Lightning so that training models can be done in a hardware-agnostic manner and scale to an arbitrary number of devices without changing any other code. 

Adding these changes removes the need for using `torch.set_default_device("cuda")` and setting default generator for dataloaders `generator=torch.Generator(device='cuda')`. Additionally, these updates ensure `num_workers>0` may be used during training, which has been seen in other issues, such as #213, and [#105](https://github.com/IntelLabs/matsciml/issues/105) from MatSci ML. 

Major changes:

Added `tensor.to()` calls to properly move tensors to the correct device during training. The device is selected based on input tensors to the respective functions where new tensors are created.  

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
