### PR TITLE
remove unnecessary float() for offering torch.float16 option

### DIFF
--- a/src/matgl/__init__.py
+++ b/src/matgl/__init__.py
@@ -39,3 +39,8 @@ def set_default_dtype(type_: str = "float", size: int = 32):
         torch.set_default_dtype(getattr(torch, f"float{size}"))
     else:
         raise ValueError("Invalid dtype size")
+    if type_ == "float" and size == 16 and not torch.cuda.is_available():
+        raise Exception(
+            "torch.float16 is not supported for M3GNet because addmm_impl_cpu_ is not implemented"
+            " for this floating precision, please use size = 32, 64 or using 'cuda' instead !!"
+        )

--- a/src/matgl/apps/pes.py
+++ b/src/matgl/apps/pes.py
@@ -132,7 +132,11 @@ class Potential(nn.Module, IOMixIn):
                     hessian[iatom] = tmp.view(-1)
 
         if self.calc_stresses:
-            volume = torch.abs(torch.det(lattice))
+            volume = (
+                torch.abs(torch.det(lattice.float())).half()
+                if matgl.float_th == torch.float16
+                else torch.abs(torch.det(lattice))
+            )
             sts = -grads[1]
             scale = 1.0 / volume * -160.21766208
             sts = [i * j for i, j in zip(sts, scale)] if sts.dim() == 3 else [sts * scale]

--- a/src/matgl/graph/compute.py
+++ b/src/matgl/graph/compute.py
@@ -23,7 +23,7 @@ def compute_pair_vector_and_distance(g: dgl.DGLGraph):
     """
     dst_pos = g.ndata["pos"][g.edges()[1]] + g.edata["pbc_offshift"]
     src_pos = g.ndata["pos"][g.edges()[0]]
-    bond_vec = (dst_pos - src_pos).float()
+    bond_vec = dst_pos - src_pos
     bond_dist = torch.norm(bond_vec, dim=1)
 
     return bond_vec, bond_dist

--- a/src/matgl/layers/_graph_convolution.py
+++ b/src/matgl/layers/_graph_convolution.py
@@ -305,7 +305,6 @@ class M3GNetGraphConv(Module):
             u = edges.src["u"]
         eij = edges.data.pop("e")
         rbf = edges.data["rbf"]
-        rbf = rbf.float()
         inputs = torch.hstack([vi, vj, eij, u]) if self.include_states else torch.hstack([vi, vj, eij])
         mij = {"mij": self.edge_update_func(inputs) * self.edge_weight_func(rbf)}
         return mij
@@ -339,7 +338,6 @@ class M3GNetGraphConv(Module):
         dst_id = graph.edges()[1]
         vj = graph.ndata["v"][dst_id]
         rbf = graph.edata["rbf"]
-        rbf = rbf.float()
         if self.include_states:
             u = dgl.broadcast_edges(graph, state_feat)
             inputs = torch.hstack([vi, vj, eij, u])

--- a/tests/test_default_dtype.py
+++ b/tests/test_default_dtype.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from matgl import set_default_dtype
+
+
+def test_set_default_dtype():
+    set_default_dtype("float", 32)
+    assert torch.get_default_dtype() == torch.float32
+    assert np.dtype("float32") == np.float32
+
+
+def test_set_default_dtype_invalid_size():
+    with pytest.raises(ValueError, match="Invalid dtype size"):
+        set_default_dtype("float", 128)
+
+
+def test_set_default_dtype_exception():
+    with pytest.raises(Exception, match="torch.float16 is not supported for M3GNet"):
+        set_default_dtype("float", 16)

--- a/tests/test_default_dtype.py
+++ b/tests/test_default_dtype.py
@@ -15,8 +15,10 @@ def test_set_default_dtype():
 def test_set_default_dtype_invalid_size():
     with pytest.raises(ValueError, match="Invalid dtype size"):
         set_default_dtype("float", 128)
+    set_default_dtype("float", 32)
 
 
 def test_set_default_dtype_exception():
     with pytest.raises(Exception, match="torch.float16 is not supported for M3GNet"):
         set_default_dtype("float", 16)
+    set_default_dtype("float", 32)


### PR DESCRIPTION
## Summary
Due to the large memory consumption for M3GNet using torch.float32, we offer torch.float16 option to reduce memory usage by removing unnecessary float() (torch.float32) in the M3GNet implementation. It should be noted that only cuda version is available for this option because the operation addmm_impl_cpu_ is not implemented for torch.float16. When the user defines the default data type as torch.float32 with cpu, the exception will raise "Exception: torch.float16 is not supported for M3GNet because addmm_impl_cpu_ is not implemented for this floating precision, please use size = 32, 64 or using 'cuda' instead !!".



## Checklist

- [ x] Google format doc strings added. Check with `ruff`.
- [ x] Type annotations included. Check with `mypy`.
- [ x] Tests added for new features/fixes.
- [ x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
