### PR TITLE
Ensure `free_energy` property is `float`

### DIFF
--- a/src/matgl/ext/ase.py
+++ b/src/matgl/ext/ase.py
@@ -177,7 +177,7 @@ class M3GNetCalculator(Calculator):
             energies, forces, stresses, hessians = self.potential(graph, lattice, state_attr_default)
         self.results.update(
             energy=energies.detach().cpu().numpy().item(),
-            free_energy=energies.detach().cpu().numpy(),
+            free_energy=energies.detach().cpu().numpy().item(),
             forces=forces.detach().cpu().numpy(),
         )
         if self.compute_stress:


### PR DESCRIPTION
This is a follow-up to #203.

The `Calculator.results` dictionary from an M3GNet run yields something like `'free_energy': array(-4.0938973, dtype=float32)` for the free energy property. This causes some havoc in places (e.g. monty jsanitization) since the array isn't iterable. It doesn't have a defined `len` without the brackets. We should really make this a `float` instead anyway. That's what I do in this PR.
