### PR TITLE
Ensure `free_energy` property is a `float` and not `np.array(float)`

### DIFF
--- a/src/matgl/ext/ase.py
+++ b/src/matgl/ext/ase.py
@@ -178,7 +178,7 @@ class PESCalculator(Calculator):
             calc_result = self.potential(graph, lattice, state_attr_default)
         self.results.update(
             energy=calc_result[0].detach().cpu().numpy().item(),
-            free_energy=calc_result[0].detach().cpu().numpy(),
+            free_energy=calc_result[0].detach().cpu().numpy().item(),
             forces=calc_result[1].detach().cpu().numpy(),
         )
         if self.compute_stress:


### PR DESCRIPTION
The `PESCalculator.results["free_energy"]` property should be formatted as a `float` but is currently formatted as a `np.array(float)`. For instance, `array(-4.0938973, dtype=float32)`. Since this is not the expected ASE type and because it is not iterable, this can cause a variety of unexpected problems. https://github.com/materialsvirtuallab/monty/issues/668 is just one example.

I have ensured the `free_energy` property is returned as a `float` in this PR.
