### PR TITLE
Move AtomRef Fitting to numpy to avoid bug

### DIFF
--- a/src/matgl/layers/_atom_ref.py
+++ b/src/matgl/layers/_atom_ref.py
@@ -41,7 +41,7 @@ class AtomRef(nn.Module):
         for i, graph in enumerate(graphs):
             atomic_numbers = graph.ndata["node_type"]
             features[i] = torch.bincount(atomic_numbers, minlength=self.max_z)
-        return features
+        return features.numpy()
 
     def fit(self, graphs: list[dgl.DGLGraph], properties: torch.Tensor) -> None:
         """Fit the elemental reference values for the properties.
@@ -51,7 +51,7 @@ class AtomRef(nn.Module):
             properties (torch.Tensor): tensor of extensive properties
         """
         features = self.get_feature_matrix(graphs)
-        self.property_offset = torch.linalg.lstsq(features, properties).solution
+        self.property_offset = np.linalg.pinv(features.T @ features) @ features.T @ np.array(properties)
 
     def forward(self, g: dgl.DGLGraph, state_attr: torch.Tensor | None = None):
         """Get the total property offset for a system.

--- a/src/matgl/layers/_atom_ref.py
+++ b/src/matgl/layers/_atom_ref.py
@@ -51,7 +51,9 @@ class AtomRef(nn.Module):
             properties (torch.Tensor): tensor of extensive properties
         """
         features = self.get_feature_matrix(graphs)
-        self.property_offset = np.linalg.pinv(features.T @ features) @ features.T @ np.array(properties)
+        self.property_offset = torch.tensor(
+            np.linalg.pinv(features.T @ features) @ features.T @ np.array(properties), dtype=matgl.float_th
+        )
 
     def forward(self, g: dgl.DGLGraph, state_attr: torch.Tensor | None = None):
         """Get the total property offset for a system.


### PR DESCRIPTION
## Summary

Change the fitting method of AtomRef from `torch.linalg.lstsq` to `np.linalg.pinv` mthod

## Issue with previous implementation

```python
for i in range(3):
    training_set, validation_set, test_set = split_dataset(
        dataset, 
        frac_list=[0.9, 0.05, 0.05], 
        random_state=42, 
        shuffle=True
    )
    train_graphs = []
    energies = []
    forces = []
    for (g, lat, l_g, attrs, lbs) in training_set:
        train_graphs.append(g)
        energies.append(lbs["energies"])
        forces.append(lbs['forces'])
    element_refs = AtomRef(torch.zeros(89))
    element_refs.fit(train_graphs, torch.hstack(energies))
    print(element_refs.property_offset)
```
The output for the above block gives:
```text
tensor([ -3.3743,  -0.3157,  -2.5775,  -3.6737,  -7.1368,  -8.9913,  -8.6316,
         -8.3601,  -6.4603,   0.0000,  -3.3769,  -4.0194,  -6.7818,  -8.5984,
         -9.2705,  -8.9952,  -7.0834,   0.0000,  -5.5053,  -7.3827, -11.5063,
        -12.9402, -13.5851, -14.2839, -14.2125, -13.8046, -12.6301, -11.5235,
        -10.0505,  -8.2310, -11.4159, -13.4431, -15.1073, -15.3583, -13.2858,
        -12.5697, -13.3787, -14.9390, -20.1400, -22.2983, -23.6922, -24.7945,
        -24.2404, -24.4331, -24.0019, -22.8785, -20.6089, -19.5086, -22.2762,
        -24.5344, -25.7248, -25.8512, -24.8157,   0.0000, -24.7562, -26.4343,
        -29.8681, -30.8821, -30.2253, -29.7089, -29.5530, -30.3643, -39.8913,
        -41.8080, -31.4633, -32.3610, -33.5807, -34.2840, -35.7176, -36.9142,
        -38.3371, -44.4273, -47.3390, -49.7190, -50.7680, -51.4679, -51.8229,
        -51.4508, -50.5201, -48.9885, -52.5689, -55.8178, -58.1974, -68.5187,
        -73.4779, -76.3807, -79.9365, -82.4917, -86.1527])
tensor([ -3.3741,  -0.3157,  -2.5770,  -3.6740,  -7.1357,  -8.9899,  -8.6315,
         -8.3597,  -6.4601,   0.0000,  -3.3769,  -4.0186,  -6.7819,  -8.5977,
         -9.2708,  -8.9946,  -7.0839,   0.0000,  -5.5013,  -7.3825, -11.5063,
        -12.9395, -13.5878, -14.2835, -14.2104, -13.8024, -12.6283, -11.5223,
        -10.0490,  -8.2301, -11.4112, -13.4407, -15.1071, -15.3573, -13.2845,
        -12.5697, -13.3787, -14.9336, -20.1477, -22.3081, -23.6842, -24.7941,
        -24.2397, -24.4296, -24.0034, -22.8813, -20.6172, -19.5162, -22.2746,
        -24.5340, -25.7308, -25.8615, -24.8152,   0.0000, -24.7562, -26.4344,
        -29.8817, -30.8813, -30.2255, -29.7091, -29.5509, -30.3798, -39.8911,
        -41.8073, -31.4633, -32.3481, -33.5813, -34.2697, -35.7157, -36.9134,
        -38.3561, -44.4379, -47.3521, -49.7313, -50.7668, -51.4649, -51.8226,
        -51.4462, -50.5176, -48.9868, -52.5704, -55.8190, -58.1957, -68.5190,
        -73.4780, -76.3839, -79.9386, -82.4904, -86.1447])
tensor([-2.3409e+00,  0.0000e+00, -3.8910e+01, -3.3982e+01, -3.6587e+00,
        -2.2113e+00, -5.9076e+00, -9.2585e+00, -2.3856e+01,  0.0000e+00,
        -9.4978e-01, -1.9004e+00, -2.2413e+00, -4.4733e+00, -2.2184e+00,
        -1.5416e+00, -4.9846e-01,  0.0000e+00, -2.4982e-01, -1.4432e+00,
        -1.5095e+00, -3.0284e+00, -1.6905e+00, -1.0165e+00, -2.1386e+00,
        -4.3439e+00, -4.6343e+00, -2.4745e+00, -2.5669e+00, -1.1788e+00,
        -1.2643e+00, -2.8717e+00, -1.3953e+00, -6.4185e-01, -4.3861e-01,
         0.0000e+00, -5.6298e-01, -2.0991e+00, -2.1398e+00, -1.4777e+00,
        -1.3475e+00, -1.0482e+00, -6.0546e-01, -4.2556e+00, -4.3206e+00,
        -2.9284e+00, -1.3899e+00, -1.2171e+00, -1.9820e+00, -1.3938e+00,
        -1.5526e+00, -7.1934e-01, -2.0661e-01,  0.0000e+00, -4.1892e-01,
         0.0000e+00, -1.4509e+00, -8.1555e-01,  0.0000e+00,  0.0000e+00,
         0.0000e+00,  0.0000e+00, -3.1925e-01, -4.8536e-01,  0.0000e+00,
         0.0000e+00,  0.0000e+00,  0.0000e+00, -1.1423e-06,  0.0000e+00,
        -3.3690e-01, -1.6648e+00, -1.7475e+00, -1.3389e+00, -2.6458e+00,
        -4.1660e+00, -4.1146e+00, -5.2788e+00, -2.3409e+00, -1.6857e+00,
        -1.1703e+00, -1.3632e+00, -1.4343e+00, -8.8050e-01, -6.5525e-01,
        -2.6236e-01, -5.4861e-01, -1.6136e+00, -4.7265e-01])
```
The fitted parameters have super large deviations from several runs.
`np.linalg.pinv` should solve the issue