### PR TITLE
Improve the TensorNet model class coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 ]
 dependencies = [
     "ase",
-    "dgl>=2.0.0",
+    "dgl",
     "pymatgen",
     "lightning",
     "torch<=2.2.1",

--- a/tests/models/test_tensornet.py
+++ b/tests/models/test_tensornet.py
@@ -21,6 +21,7 @@ class TestTensorNet:
         os.remove("model.pt")
         os.remove("model.json")
         os.remove("state.pt")
+        model = TensorNet(is_intensive=False, equivariance_invariance_group="SO(3)")
 
     def test_exceptions(self):
         with pytest.raises(ValueError, match="Invalid activation type"):

--- a/tests/models/test_tensornet.py
+++ b/tests/models/test_tensornet.py
@@ -22,6 +22,7 @@ class TestTensorNet:
         os.remove("model.json")
         os.remove("state.pt")
         model = TensorNet(is_intensive=False, equivariance_invariance_group="SO(3)")
+        assert torch.numel(output) == 1
 
     def test_exceptions(self):
         with pytest.raises(ValueError, match="Invalid activation type"):


### PR DESCRIPTION
## Summary
A unit test is added for testing SO(3) equivariance to improve the coverage.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
