### PR TITLE
Allow missing label in MGLDataset

### DIFF
--- a/src/matgl/utils/training.py
+++ b/src/matgl/utils/training.py
@@ -502,7 +502,7 @@ class PotentialLightningModule(MatglLightningModuleMixin, pl.LightningModule):
             s_rmse = self.rmse(valid_labels[2], valid_preds[2])
             total_loss = total_loss + self.stress_weight * s_loss
 
-        if self.model.calc_magmom and len(labels[3]) > 0:
+        if self.model.calc_magmom and labels[3].numel() > 0:
             if self.magmom_target == "symbreak":
                 m_loss = torch.min(
                     loss(valid_labels[3], valid_preds[3], **self.loss_params),

--- a/tests/utils/test_training.py
+++ b/tests/utils/test_training.py
@@ -773,6 +773,97 @@ class TestModelTrainer:
 
         self.teardown_class()
 
+    def test_chgnet_training_with_missing_label(self, LiFePO4, BaNiO3):
+        isolated_atom = Structure(Lattice.cubic(10.0), ["Li"], [[0, 0, 0]])
+        two_body = Structure(Lattice.cubic(10.0), ["Li", "Li"], [[0, 0, 0], [0.5, 0, 0]])
+        structures = [LiFePO4, BaNiO3] * 5 + [isolated_atom, two_body]
+        energies = [-2.0, -3.0] * 5 + [-1.0, -1.5]
+        forces = [np.zeros((len(s), 3)).tolist() for s in structures]
+        stresses = [np.zeros((3, 3)).tolist()] * len(structures)
+        magmoms = [np.zeros((len(s), 1)).tolist() for s in structures]
+        # Create some missing labels
+        energies[2] = None
+        forces[4] = None
+        stresses[6] = None
+        magmoms[8] = None
+
+        element_types = get_element_list([LiFePO4, BaNiO3])
+        converter = Structure2Graph(element_types=element_types, cutoff=6.0)
+        dataset = MGLDataset(
+            threebody_cutoff=3.0,
+            structures=structures,
+            converter=converter,
+            include_line_graph=True,
+            directed_line_graph=True,
+            labels={
+                "energies": energies,
+                "forces": forces,
+                "stresses": stresses,
+                "magmoms": magmoms,
+            },
+            save_cache=False,
+        )
+        train_data, val_data, test_data = split_dataset(
+            dataset,
+            frac_list=[0.8, 0.1, 0.1],
+            shuffle=True,
+            random_state=42,
+        )
+        train_loader, val_loader, test_loader = MGLDataLoader(
+            train_data=train_data,
+            val_data=val_data,
+            test_data=test_data,
+            collate_fn=partial(collate_fn_pes, include_magmom=True, include_line_graph=True),
+            batch_size=2,
+            num_workers=0,
+            generator=torch.Generator(device=device),
+        )
+        model = CHGNet(element_types=element_types, is_intensive=False)
+        lit_model = PotentialLightningModule(
+            model=model,
+            stress_weight=0.1,
+            magmom_weight=0.1,
+            include_line_graph=True,
+            allow_missing_labels=True,
+        )
+        # We will use CPU if MPS is available since there is a serious bug.
+        trainer = pl.Trainer(max_epochs=2, accelerator=device, inference_mode=False)
+
+        trainer.fit(model=lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
+        trainer.test(lit_model, dataloaders=test_loader)
+
+        pred_LFP_energy = model.predict_structure(LiFePO4)
+        pred_BNO_energy = model.predict_structure(BaNiO3)
+
+        assert torch.any(pred_LFP_energy < 0)
+        assert torch.any(pred_BNO_energy < 0)
+        # specify customize optimizer and scheduler
+        from torch.optim.lr_scheduler import CosineAnnealingLR
+
+        optimizer = torch.optim.AdamW(model.parameters(), lr=1.0e-3, weight_decay=1.0e-5, amsgrad=True)
+        scheduler = CosineAnnealingLR(optimizer, T_max=1000 * 10, eta_min=1.0e-2 * 1.0e-3)
+        lit_model = PotentialLightningModule(
+            model=model,
+            stress_weight=0.1,
+            magmom_weight=0.1,
+            include_line_graph=True,
+            loss="huber_loss",
+            optimizer=optimizer,
+            scheduler=scheduler,
+        )
+        trainer = pl.Trainer(max_epochs=2, accelerator=device, inference_mode=False)
+
+        trainer.fit(model=lit_model, train_dataloaders=train_loader, val_dataloaders=val_loader)
+        trainer.test(lit_model, dataloaders=test_loader)
+
+        pred_LFP_energy = model.predict_structure(LiFePO4)
+        pred_BNO_energy = model.predict_structure(BaNiO3)
+
+        assert pred_LFP_energy < 0
+        assert pred_BNO_energy < 0
+
+        self.teardown_class()
+
     @classmethod
     def teardown_class(cls):
         try:

--- a/tests/utils/test_training.py
+++ b/tests/utils/test_training.py
@@ -775,7 +775,7 @@ class TestModelTrainer:
 
     def test_chgnet_training_with_missing_label(self, LiFePO4, BaNiO3):
         structures = [LiFePO4, BaNiO3] * 5
-        energies = [-2.0, -3.0] * 5 + [-1.0, -1.5]
+        energies = [-2.0, -3.0] * 5
         forces = [np.ones((len(s), 3)).tolist() for s in structures]
         stresses = [np.zeros((3, 3)).tolist()] * len(structures)
         magmoms = [np.ones((len(s), 1)).tolist() for s in structures]


### PR DESCRIPTION
## Summary
This PR allows loss function calculation in MGLDataset.
Now we're able to train with the dataset of partial labels.
The default behavior of the training and loss function is `allow_missing_labels: bool = False`
So this PR does not influence the performance of previous working codes.

Major changes:

- `src/matgl/utils/training.py`
- `tests/utils/test_training.py`

Example:
```
energies[2] = np.nan
forces[4] = (np.nan * np.ones((len(structures[4]), 3))).tolist()
stresses[6] = (np.nan * np.ones((3, 3))).tolist()
magmoms[8] = (np.nan * np.ones((len(structures[8]), 1))).tolist()

dataset = MGLDataset(
    structures=structures,
    converter=converter,
    labels={
        "energies": energies,
        "forces": forces,
        "stresses": stresses,
        "magmoms": magmoms,
    },
)
```
The above dataset with some missing labels should be now trainable