### PR TITLE
Update README.md to have clearer torch installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ and DGL. The basic instructions are given below, but it is recommended that you 
 run into any problems.
 
 ```shell
-pip install torch==2.2.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
-pip install dgl -f https://data.dgl.ai/wheels/cu118/repo.html
+pip install torch==2.2.0 --index-url https://download.pytorch.org/whl/cu121
+pip install dgl -f https://data.dgl.ai/wheels/cu121/repo.html
 pip install dglgo -f https://data.dgl.ai/wheels-test/repo.html
 ```
 


### PR DESCRIPTION
## Summary

Closes https://github.com/materialsvirtuallab/matgl/issues/572. The installation instructions now recommend `torch==2.2.0` instead of `torch==2.2.1` since the latter is not supported by matgl's `pyproject.toml`. I also removed `torchvision` and `torchaudio`, which are not needed here, and I switched to `cu121` in place of `cu118` since CUDA 12.1 is the highest version supported by the current dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the installation instructions to reflect revised recommended versions for PyTorch and DGL, ensuring enhanced compatibility with newer CUDA requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->