### PR TITLE
Add upper python version specifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ authors = [
 ]
 description = "MatGL is a framework for graph deep learning for materials science."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 keywords = [
     "materials",
     "interatomic potential",
@@ -42,6 +42,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Chemistry",
     "Topic :: Scientific/Engineering :: Information Analysis",


### PR DESCRIPTION
## Summary

- Add upper python version specifier

Using an explicit upper-bound specifier helps prevent package managers (e.g., pip) from installing the package on unsupported future Python versions 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project compatibility to support Python versions 3.10 through less than 3.13.
	- Explicitly added support for Python 3.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->