### PR TITLE
Example notebook for fine-tuning M3GNet potential on a customized dataset with DIRECT sampling

### DIFF
--- a/examples/Fine-Tuning a M3GNet Potential on the Customized Dataset with DIRECT Sampling.ipynb
+++ b/examples/Fine-Tuning a M3GNet Potential on the Customized Dataset with DIRECT Sampling.ipynb
@@ -39,8 +39,8 @@
     "from matgl.config import DEFAULT_ELEMENTS\n",
     "from matgl.ext.pymatgen import Structure2Graph\n",
     "from matgl.graph.data import MGLDataLoader, MGLDataset, collate_fn_pes\n",
-    "from matgl.models import M3GNet\n",
     "from matgl.utils.training import PotentialLightningModule\n",
+    "\n",
     "try:\n",
     "    from maml.sampling.direct import BirchClustering, DIRECTSampler, SelectKFromClusters\n",
     "except ImportError:\n",
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e96ec08-7d4b-4356-93dc-b4e84a426c97",
+   "id": "4",
    "metadata": {
     "id": "eaafc0bd"
    },
@@ -115,7 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d8d1d3c-4adb-49ab-94f3-4a79e97d1e3d",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +129,7 @@
   },
   {
    "cell_type": "raw",
-   "id": "e0a70926-d4b1-46c9-a4c5-7b989738c8df",
+   "id": "6",
    "metadata": {
     "id": "eaafc0bd"
    },
@@ -140,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "659b2255-0d63-4805-a560-c4e66d423adb",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,16 +148,16 @@
     "selected_indexes = DIRECT_selection[\"selected_indexes\"]\n",
     "selected_structures = structures[selected_indexes]\n",
     "selected_labels = {}\n",
-    "selected_labels['energies'] = energies[selected_indexes]\n",
-    "selected_labels['forces'] = forces[selected_indexes]\n",
-    "selected_labels['stresses'] = stresses[selected_indexes]\n",
+    "selected_labels[\"energies\"] = energies[selected_indexes]\n",
+    "selected_labels[\"forces\"] = forces[selected_indexes]\n",
+    "selected_labels[\"stresses\"] = stresses[selected_indexes]\n",
     "\n",
     "print(f\"{len(selected_structures)} structures selected from DIRECT\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "8",
    "metadata": {
     "id": "f666cb23"
    },
@@ -168,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "9",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"


### PR DESCRIPTION
## Summary
Adding an example notebook for fine-tuning the pretrained M3GNet potential on a customized dataset with DIRECT sampling
Major changes:



## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
