### PR TITLE
Add `element_types` kwarg to example notebook

### DIFF
--- a/examples/Training a MEGNet Formation Energy Model with PyTorch Lightning.ipynb
+++ b/examples/Training a MEGNet Formation Energy Model with PyTorch Lightning.ipynb
@@ -220,7 +220,7 @@
     "    hidden_layer_sizes_output=(32, 16),\n",
     "    is_classification=False,\n",
     "    activation_type=\"softplus2\",\n",
-    "    element_types=element_types,\n",
+    "    element_types=elem_list,\n",
     "    bond_expansion=bond_expansion,\n",
     "    cutoff=4.0,\n",
     "    gauss_width=0.5,\n",


### PR DESCRIPTION
## Summary

This PR updates the "[Training a MEGNet Formation Energy Model with PyTorch Lightning.ipynb](https://github.com/materialsvirtuallab/matgl/blob/main/examples/Training%20a%20MEGNet%20Formation%20Energy%20Model%20with%20PyTorch%20Lightning.ipynb)" to add the `element_types` keyword argument to the `MEGNet()` class. Without this, the user is likely to make an error when making predictions with the trained model.

Closes #609.