### PR TITLE
Added a dropout argument to the M3GNET constructor

### DIFF
--- a/src/matgl/models/_m3gnet.py
+++ b/src/matgl/models/_m3gnet.py
@@ -80,6 +80,7 @@ class M3GNet(MatGLModel):
         field: Literal["node_feat", "edge_feat"] = "node_feat",
         include_state: bool = False,
         activation_type: Literal["swish", "tanh", "sigmoid", "softplus2", "softexp"] = "swish",
+        dropout: float | None = None,
         **kwargs,
     ):
         """
@@ -108,6 +109,7 @@ class M3GNet(MatGLModel):
             nlayers_set2set (int): Number of set2set layers
             include_state (bool): Whether to include states features
             activation_type (str): Activation type. choose from 'swish', 'tanh', 'sigmoid', 'softplus2', 'softexp'
+            dropout (float): Dropout probability to apply in graph layers during training
             **kwargs: For future flexibility. Not used at the moment.
         """
         super().__init__()
@@ -174,6 +176,7 @@ class M3GNet(MatGLModel):
                     dim_edge_feats=dim_edge_embedding,
                     dim_state_feats=dim_state_feats,
                     include_state=include_state,
+                    dropout=dropout,
                 )
                 for _ in range(nblocks)
             }


### PR DESCRIPTION
The constructor simply passes the value down to the underlying M3GNetBlock layers. The default value is None (corresponding to no dropout), the same as for the M3GNetBlock layers - so there is no change to default behaviour. I'm using this to regularize my models - and it's working as intended.

## Summary

Changes:

- feature 1: Added a parameter to the constructor of a M3GNet model that allows passing down a dropout value. The default value preserves current behaviour.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- (N/A) Tests added for new features/fixes .
- (N/A) If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
