### PR TITLE
Fix import of `ExpCellFilter`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "ase>=3.26.0",
+    "ase",
     "torch<=2.7.0",  # TODO: Remove this pin. For some reason, torch 2.9 gives different results.
     "torchdata",
     "pymatgen",


### PR DESCRIPTION
## Summary

The `ExpCellFilter` can now only be found under `ase.filters` instead of `ase.constraints`. See https://gitlab.com/ase/ase/-/merge_requests/3544 for detail. The latter was deprecated and has recently been removed in the `main` branch of ASE as of two months ago.

I have updated `matgl.ext._ase_pyg.py` accordingly.

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
