### PR TITLE
Remove `ase_cellfilter` parameter from `relax`

### DIFF
--- a/src/matgl/ext/_ase_dgl.py
+++ b/src/matgl/ext/_ase_dgl.py
@@ -17,7 +17,7 @@ import scipy.sparse as sp
 import torch
 from ase import Atoms, units
 from ase.calculators.calculator import Calculator, all_changes
-from ase.filters import FrechetCellFilter
+from ase.filters import Filter, FrechetCellFilter
 from ase.md import Langevin
 from ase.md.andersen import Andersen
 from ase.md.bussi import Bussi
@@ -346,7 +346,7 @@ class Relaxer:
         if traj_file is not None:
             obs.save(traj_file)
 
-        if isinstance(atoms, FrechetCellFilter):
+        if isinstance(atoms, Filter):
             atoms = atoms.atoms
 
         final_structure: Structure | Molecule


### PR DESCRIPTION
## Summary

The `ase_cellfilter` keyword argument in `matgl.ext._ase_dgl.py` was unused and has now been removed.

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
