### PR TITLE
[WIP] Enable inference on GPU for pyg ASE calculator

### DIFF
--- a/src/matgl/ext/_ase_pyg.py
+++ b/src/matgl/ext/_ase_pyg.py
@@ -14,6 +14,7 @@ import ase.optimize as opt
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
+import torch
 from ase import Atoms, units
 from ase.calculators.calculator import Calculator, all_changes
 from ase.filters import Filter, FrechetCellFilter
@@ -29,7 +30,6 @@ from ase.stress import full_3x3_to_voigt_6_stress
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.io.ase import AseAtomsAdaptor
 from pymatgen.optimization.neighbors import find_points_in_spheres
-import torch
 
 from matgl.graph._converters_pyg import GraphConverter
 


### PR DESCRIPTION
## Summary

Major changes:

- Allows inference to run on GPU for pyg ASE calculator. This can be done via the newly added `device` argument to the `PESCalculator`. 

## Todos

- Just did a quick fix to make it work for `PESCalculator`. Should update other calculators. 

## Questions 

- Potentials like `TensorNet` expect `state_attr` to be a torch.Tensor. But `Atoms2Graph` returns a `list | np.ndarray`. Currently, I've changed `Atoms2Graph` to return a `torch.Tensor`, but this might not be a good idea since `Atoms2Graph` can be used in other places. Alternatively, the type conversion can be done within the `PESCalculator.calculate` method. Any suggestions? 



## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
