### PR TITLE
Converting PyG TensorNet Interaction and Embedding blocks into pure Torch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 ]
 dependencies = [
     "ase",
-    "torch<=2.8.0",  # TODO: Remove this pin. For some reason, torch 2.9 gives different results.
+    "torch<=2.9.1",  # TODO: Remove this pin. For some reason, torch 2.9 gives different results.
     "torchdata",
     "pymatgen",
     "lightning<=2.6.0",

--- a/src/matgl/layers/_embedding_pyg.py
+++ b/src/matgl/layers/_embedding_pyg.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 import torch
 from torch import nn
-from torch_geometric.nn import MessagePassing
 
 import matgl
 from matgl.utils.cutoff import cosine_cutoff
@@ -22,7 +21,7 @@ if TYPE_CHECKING:
     from torch_geometric.data import Data
 
 
-class TensorEmbedding(MessagePassing):
+class TensorEmbedding(nn.Module):
     """Embedding block for TensorNet to generate node, edge, and optional state features using PyG.
     Adapted from the DGL implementation in https://github.com/torchmd/torchmd-net.
     """
@@ -45,7 +44,7 @@ class TensorEmbedding(MessagePassing):
             cutoff (float): Cutoff radius for graph construction.
             dtype (torch.dtype): Data type for all variables.
         """
-        super().__init__(aggr="add")  # Use 'add' aggregation for summing messages
+        super().__init__()
         self.units = units
         self.cutoff = cutoff
 

--- a/src/matgl/layers/_graph_convolution_pyg.py
+++ b/src/matgl/layers/_graph_convolution_pyg.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
-from torch_geometric.nn import MessagePassing
 
 from matgl.utils.cutoff import cosine_cutoff
 from matgl.utils.maths import (
@@ -18,7 +17,7 @@ if TYPE_CHECKING:
     from torch_geometric.data import Data
 
 
-class TensorNetInteraction(MessagePassing):
+class TensorNetInteraction(nn.Module):
     """A Graph Convolution block for TensorNet adapted for PyTorch Geometric."""
 
     def __init__(
@@ -39,7 +38,7 @@ class TensorNetInteraction(MessagePassing):
             equivariance_invariance_group: Group action on geometric tensor representations, either O(3) or SO(3).
             dtype: Data type for all variables.
         """
-        super().__init__(aggr="add")  # Aggregate messages by summation
+        super().__init__()
         self.num_rbf = num_rbf
         self.units = units
         self.cutoff = cutoff


### PR DESCRIPTION
## Summary
Converting PyG TensorNet Interaction and Embedding blocks into pure Torch

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
