### PR TITLE
TensorNetWrapper for NVIDIA Toolkit for fully GPU-resident MD/Relax workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,9 @@ jobs:
             optionals: "ops"
           - os: ubuntu-latest
             python: "3.13"
+            optionals: "alchmtk"
+          - os: ubuntu-latest
+            python: "3.13"
           - os: macos-latest
             python: "3.11"
 

--- a/examples/NVT MD with TensorNet and nvalchemi-toolkit.py
+++ b/examples/NVT MD with TensorNet and nvalchemi-toolkit.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+NVT Molecular Dynamics with TensorNet and nvalchemi-toolkit
+============================================================
+
+This example runs NVT Langevin molecular dynamics on a periodic LiFePO4
+crystal using a pretrained MatGL TensorNet potential wrapped for the
+nvalchemi-toolkit dynamics engine.
+
+The workflow:
+
+1. Load a pretrained TensorNet potential from MatGL.
+2. Wrap it with :class:`~matgl.ext.alchmtk.TensorNetWrapper`.
+3. Build a periodic LiFePO4 structure using pymatgen.
+4. Convert to :class:`~nvalchemi.data.AtomicData` via ``from_structure``.
+5. Run 1000 NVT Langevin steps at 300 K.
+6. Compute final temperature from kinetic energy.
+
+Requirements::
+
+    pip install matgl[alchmtk]
+
+"""
+
+from __future__ import annotations
+
+import torch
+from nvalchemi.data import AtomicData, Batch
+from nvalchemi.dynamics import NVTLangevin
+from nvalchemi.dynamics.base import DynamicsStage
+from nvalchemi.dynamics.hooks import LoggingHook
+from pymatgen.util.testing import PymatgenTest
+
+import matgl
+from matgl.ext.alchmtk import TensorNetWrapper
+
+# %%
+# Load and wrap model
+# --------------------
+# Load a pretrained TensorNet PES potential from MatGL and wrap it
+# with ``TensorNetWrapper`` for use in nvalchemi dynamics.
+
+potential = matgl.load_model("TensorNet-MatPES-PBE-v2025.1-PES")
+model = TensorNetWrapper.from_potential(potential)
+
+print(f"Model: TensorNet (cutoff={model.model.cutoff} A, units={model.model.units})")
+print(f"Outputs: {model.model_config.outputs}")
+print(f"Active:  {model.model_config.active_outputs}")
+
+# %%
+# Build structure
+# ----------------
+# Load the LiFePO4 structure (28 atoms) from pymatgen's test database.
+# ``from_structure`` handles periodic boundary conditions automatically.
+
+structure = PymatgenTest.get_structure("LiFePO4")
+n_atoms = len(structure)
+
+# %%
+# Build AtomicData with initial fields
+# --------------------------------------
+# The integrator requires ``forces``, ``energy``, and ``velocities``
+# to be present on the batch before the first step.  We initialize
+# forces and energy to zero (the model overwrites them at the first
+# BEFORE_COMPUTE hook) and sample velocities from Maxwell-Boltzmann.
+
+T_TARGET = 300.0  # K
+KB_EV = 8.617333262e-5  # eV/K
+
+data = AtomicData.from_structure(structure)
+data.forces = torch.zeros(n_atoms, 3)
+data.energy = torch.zeros(1, 1)
+
+# Maxwell-Boltzmann velocities at T_TARGET
+torch.manual_seed(42)
+masses = data.atomic_masses  # amu
+v_scale = (KB_EV * T_TARGET / masses).sqrt().unsqueeze(-1)
+velocities = torch.randn(n_atoms, 3) * v_scale
+velocities -= velocities.mean(dim=0, keepdim=True)  # zero COM velocity
+data.add_node_property("velocities", velocities)
+
+batch = Batch.from_data_list([data])
+print(f"\nStructure: {structure.formula} ({n_atoms} atoms, cubic {structure.lattice.a:.1f} A)")
+
+# %%
+# NVTLangevin integrator and hooks
+# ----------------------------------
+# :class:`~nvalchemi.dynamics.NVTLangevin` implements the BAOAB Langevin
+# splitting scheme.  Key arguments:
+#
+# * ``dt`` — timestep in fs
+# * ``temperature`` — target temperature in K
+# * ``friction`` — Langevin friction in 1/fs
+# * ``random_seed`` — reproducible stochastic forces
+#
+# The neighbor list hook is registered via ``model.make_neighbor_hooks()``,
+# which reads the model's ``NeighborConfig`` and creates the appropriate hook.
+
+nvt = NVTLangevin(
+    model=model,
+    dt=1.0,
+    temperature=T_TARGET,
+    friction=0.01,
+    random_seed=42,
+    n_steps=1000,
+)
+
+for hook in model.make_neighbor_hooks():
+    nvt.register_hook(hook, stage=DynamicsStage.BEFORE_COMPUTE)
+
+with LoggingHook(backend="csv", log_path="md_log.csv", frequency=10) as log_hook:
+    nvt.register_hook(log_hook)
+
+    print(f"\nRunning {nvt.n_steps} NVT steps at T={T_TARGET} K ...")
+    batch = nvt.run(batch)
+    print(f"NVT completed {nvt.step_count} steps.")
+
+# %%
+# Inspecting temperature
+# -----------------------
+# The instantaneous kinetic temperature is computed from the
+# equipartition theorem:
+#
+#   T = (2 · KE) / (3 · N · kB)
+
+masses = batch.atomic_masses  # (N,) amu
+vels = batch.velocities  # (N, 3)
+ke_ev = 0.5 * (masses * (vels**2).sum(dim=-1)).sum().item()
+T_final = (2.0 * ke_ev) / (3.0 * n_atoms * KB_EV)
+
+print(f"\nFinal temperature: {T_final:.1f} K (target: {T_TARGET} K)")
+print(f"Final energy: {batch.energy.item():.4f} eV")
+print("MD trajectory saved to md_log.csv")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ dgl = [
 ops = [
   "nvalchemi-toolkit-ops",
 ]
+alchmtk = [
+  "nvalchemi-toolkit",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/matgl/ext/_tensornet_alchmtk.py
+++ b/src/matgl/ext/_tensornet_alchmtk.py
@@ -148,12 +148,11 @@ class TensorNetWrapper(nn.Module, BaseModelMixin):  # type: ignore[misc]
         self.model = model
 
         # ZBL nuclear repulsion (fixed analytical potential)
+        self.repuls: NuclearRepulsionPyG | None = None  # type: ignore[name-defined]
         if calc_repuls:
             from matgl.layers._zbl_pyg import NuclearRepulsionPyG
 
             self.repuls = NuclearRepulsionPyG(float(model.cutoff))
-        else:
-            self.repuls = None
 
         self.model_config = ModelConfig(
             outputs=frozenset({"energy", "forces", "stress"}),
@@ -222,8 +221,8 @@ class TensorNetWrapper(nn.Module, BaseModelMixin):  # type: ignore[misc]
 
         return cls(
             model=potential.model,
-            data_mean=potential.data_mean.clone(),
-            data_std=potential.data_std.clone(),
+            data_mean=potential.data_mean.clone(),  # type: ignore[operator]
+            data_std=potential.data_std.clone(),  # type: ignore[operator]
             element_refs=element_refs,
             calc_repuls=getattr(potential, "calc_repuls", False),
         )
@@ -277,7 +276,7 @@ class TensorNetWrapper(nn.Module, BaseModelMixin):  # type: ignore[misc]
         device = data.positions.device
         B: int = data.num_graphs
 
-        node_type = self._z_to_type[data.atomic_numbers]
+        node_type = self._z_to_type[data.atomic_numbers]  # type: ignore[index]
 
         # nvalchemi (E, 2) -> TensorNet/PyG (2, E)
         edge_index = data.neighbor_list.T  # [2, E]

--- a/src/matgl/ext/_tensornet_alchmtk.py
+++ b/src/matgl/ext/_tensornet_alchmtk.py
@@ -1,0 +1,490 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""nvalchemi-toolkit wrapper for TensorNet (PyG backend).
+
+Wraps :class:`~matgl.models._tensornet_pyg.TensorNet` as a
+:class:`~nvalchemi.models.base.BaseModelMixin`-compatible model for use in
+nvalchemi dynamics pipelines (molecular dynamics and geometry optimization).
+
+Usage
+-----
+Load a pre-trained TensorNet potential and wrap it::
+
+    import matgl
+    from matgl.ext.alchmtk import TensorNetWrapper
+
+    potential = matgl.load_model("TensorNet-MatPES-PBE-v2025.1-PES")
+    model = TensorNetWrapper.from_potential(potential)
+
+    from nvalchemi.hooks import NeighborListHook
+    from nvalchemi.dynamics.base import DynamicsStage
+
+    nl_hook = NeighborListHook(model.model_config.neighbor_config, stage=DynamicsStage.BEFORE_COMPUTE)
+    dynamics.register_hook(nl_hook)
+    dynamics.model = model
+
+Notes:
+-----
+* Energy is the primitive output. Forces and stresses are derived via
+  autograd (``autograd_outputs={"forces", "stress"}``).
+* Stresses use the affine strain trick via
+  :func:`~nvalchemi.models._utils.prepare_strain` and
+  :func:`~nvalchemi.models._utils.autograd_stresses`.
+  Output unit is eV/A^3, Cauchy convention (``-dE/d(strain)/V``).
+* Requires :class:`~nvalchemi.hooks.NeighborListHook` with
+  ``format=NeighborListFormat.COO`` to populate ``neighbor_list`` and
+  ``neighbor_list_shifts`` before each model call.
+* Only ``is_intensive=False`` models are supported (total energy, not
+  per-atom properties).
+* ZBL nuclear repulsion is optionally included via ``calc_repuls``.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import TYPE_CHECKING, Any
+
+import torch
+from pymatgen.core.periodic_table import Element
+from torch import nn
+
+from matgl.models._tensornet_pyg import TensorNet
+
+try:
+    from nvalchemi.data import AtomicData, Batch
+    from nvalchemi.models._utils import (
+        autograd_forces,
+        autograd_stresses,
+        prepare_strain,
+    )
+    from nvalchemi.models.base import (
+        BaseModelMixin,
+        ModelConfig,
+        NeighborConfig,
+        NeighborListFormat,
+    )
+
+    _NVALCHEMI_AVAILABLE = True
+except ImportError:
+    _NVALCHEMI_AVAILABLE = False
+    BaseModelMixin = object  # type: ignore[misc,assignment]
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from nvalchemi._typing import ModelOutputs
+
+    from matgl.apps._pes_pyg import Potential
+
+__all__ = ["TensorNetWrapper"]
+
+
+class TensorNetWrapper(nn.Module, BaseModelMixin):  # type: ignore[misc]
+    """nvalchemi-toolkit wrapper for TensorNet (PyG backend).
+
+    Parameters
+    ----------
+    model : TensorNet
+        An instantiated TensorNet model.  Must have ``is_intensive=False``.
+    data_mean : float or torch.Tensor, optional
+        Training-target mean for energy un-normalization.  Default: 0.0.
+    data_std : float or torch.Tensor, optional
+        Training-target standard deviation.  Default: 1.0.
+    element_refs : torch.Tensor or None, optional
+        Per-element-type energy offsets, shape ``[num_element_types]``.
+        Added to the total energy after un-normalization.  Default: None.
+    calc_repuls : bool, optional
+        Include ZBL nuclear repulsion.  Default: False.
+    """
+
+    model: TensorNet
+
+    def __init__(
+        self,
+        model: TensorNet,
+        data_mean: float | torch.Tensor = 0.0,
+        data_std: float | torch.Tensor = 1.0,
+        element_refs: torch.Tensor | None = None,
+        calc_repuls: bool = False,
+    ) -> None:
+        if not _NVALCHEMI_AVAILABLE:
+            raise ImportError(
+                "nvalchemi-toolkit is required to use TensorNetWrapper. Install it with: pip install nvalchemi-toolkit"
+            )
+        super().__init__()
+
+        if model.is_intensive:
+            raise ValueError(
+                "TensorNetWrapper requires is_intensive=False (total-energy prediction). "
+                "Intensive models (per-atom properties) are not supported for MD/relaxation."
+            )
+
+        self.model = model
+
+        # ZBL nuclear repulsion (fixed analytical potential)
+        if calc_repuls:
+            from matgl.layers._zbl_pyg import NuclearRepulsionPyG
+
+            self.repuls = NuclearRepulsionPyG(float(model.cutoff))
+        else:
+            self.repuls = None
+
+        self.model_config = ModelConfig(
+            outputs=frozenset({"energy", "forces", "stress"}),
+            active_outputs={"energy", "forces", "stress"},
+            autograd_outputs=frozenset({"forces", "stress"}),
+            autograd_inputs=frozenset({"positions"}),
+            required_inputs=frozenset(),
+            optional_inputs=frozenset({"neighbor_list_shifts", "cell"}),
+            supports_pbc=True,
+            needs_pbc=False,
+            neighbor_config=NeighborConfig(
+                cutoff=float(self.model.cutoff),
+                format=NeighborListFormat.COO,
+                half_list=False,
+            ),
+        )
+
+        if not isinstance(data_mean, torch.Tensor):
+            data_mean = torch.tensor(data_mean, dtype=torch.float32)
+        if not isinstance(data_std, torch.Tensor):
+            data_std = torch.tensor(data_std, dtype=torch.float32)
+        self.register_buffer("data_mean", data_mean)
+        self.register_buffer("data_std", data_std)
+
+        if element_refs is not None:
+            if not isinstance(element_refs, torch.Tensor):
+                element_refs = torch.tensor(element_refs, dtype=torch.float32)
+            self.register_buffer("_element_ref_offset", element_refs)
+        else:
+            self._element_ref_offset: torch.Tensor | None = None
+
+        self._build_z_to_type_table()
+
+    def _build_z_to_type_table(self) -> None:
+        """Build a ``[max_z + 1]`` lookup: atomic number -> type index."""
+        symbol_to_idx = {sym: i for i, sym in enumerate(self.model.element_types)}
+        max_z = max(Element(sym).Z for sym in self.model.element_types)
+        table = torch.full((max_z + 1,), -1, dtype=torch.long)
+        for sym, idx in symbol_to_idx.items():
+            table[Element(sym).Z] = idx
+        self.register_buffer("_z_to_type", table, persistent=False)
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_potential(cls, potential: Potential) -> TensorNetWrapper:
+        """Construct from a matgl :class:`~matgl.apps._pes_pyg.Potential`.
+
+        Parameters
+        ----------
+        potential : Potential
+            A matgl ``Potential`` wrapping a ``TensorNet`` model.
+
+        Returns:
+        -------
+        TensorNetWrapper
+        """
+        if not isinstance(potential.model, TensorNet):
+            raise TypeError(f"Expected potential.model to be TensorNet, got {type(potential.model).__name__}.")
+
+        element_refs = None
+        if potential.element_refs is not None:
+            element_refs = potential.element_refs.property_offset.clone()
+
+        return cls(
+            model=potential.model,
+            data_mean=potential.data_mean.clone(),
+            data_std=potential.data_std.clone(),
+            element_refs=element_refs,
+            calc_repuls=getattr(potential, "calc_repuls", False),
+        )
+
+    # ------------------------------------------------------------------
+    # BaseModelMixin interface
+    # ------------------------------------------------------------------
+
+    @property
+    def embedding_shapes(self) -> dict[str, tuple[int, ...]]:
+        """Return ``{node_embeddings: (units,), graph_embeddings: (units,)}``."""
+        units: int = self.model.units
+        return {
+            "node_embeddings": (units,),
+            "graph_embeddings": (units,),
+        }
+
+    def _model_dtype(self) -> torch.dtype:
+        """Return the dtype of TensorNet parameters."""
+        try:
+            return next(self.model.parameters()).dtype
+        except StopIteration:
+            return torch.float32
+
+    # ------------------------------------------------------------------
+    # adapt_input
+    # ------------------------------------------------------------------
+
+    def adapt_input(self, data: AtomicData | Batch, **kwargs: Any) -> dict[str, Any]:
+        """Convert nvalchemi ``Batch`` to TensorNet inputs.
+
+        Reads ``neighbor_list`` and ``neighbor_list_shifts`` directly
+        from the batch (populated by :class:`~nvalchemi.hooks.NeighborListHook`).
+        Does **not** call ``super().adapt_input()`` — ``Batch`` lacks
+        ``model_dump()`` which the base implementation requires.
+        Gradient setup is handled by ``forward()`` before this call.
+
+        Parameters
+        ----------
+        data : AtomicData | Batch
+            A bare ``AtomicData`` is promoted to a single-graph ``Batch``.
+
+        Returns:
+        -------
+        dict[str, Any]
+        """
+        if isinstance(data, AtomicData):
+            data = Batch.from_data_list([data])
+
+        dtype = self._model_dtype()
+        device = data.positions.device
+        B: int = data.num_graphs
+
+        node_type = self._z_to_type[data.atomic_numbers]
+
+        # nvalchemi (E, 2) -> TensorNet/PyG (2, E)
+        edge_index = data.neighbor_list.T  # [2, E]
+        E: int = edge_index.shape[1]
+
+        shifts_raw = getattr(data, "neighbor_list_shifts", None)
+        if shifts_raw is None:
+            shifts = torch.zeros(E, 3, dtype=dtype, device=device)
+        else:
+            shifts = shifts_raw.to(dtype=dtype, device=device)
+
+        cell_raw = getattr(data, "cell", None)
+        if cell_raw is None:
+            cell = torch.eye(3, dtype=dtype, device=device).unsqueeze(0).expand(B, -1, -1)
+        else:
+            cell = cell_raw.to(dtype=dtype, device=device)
+
+        positions = data.positions.to(dtype=dtype)
+        edge_batch = data.batch_idx[edge_index[0]]
+        pbc_offshift = torch.einsum("eb,ebc->ec", shifts, cell[edge_batch])
+
+        return {
+            "node_type": node_type,
+            "pos": positions,
+            "edge_index": edge_index,
+            "pbc_offshift": pbc_offshift,
+            "batch": data.batch_idx,
+            "num_graphs": B,
+        }
+
+    # ------------------------------------------------------------------
+    # adapt_output
+    # ------------------------------------------------------------------
+
+    def adapt_output(
+        self,
+        model_output: dict[str, Any],
+        data: AtomicData | Batch,
+    ) -> ModelOutputs:
+        """Map results to nvalchemi ``ModelOutputs``."""
+        output = super().adapt_output(model_output, data)
+        output["energy"] = model_output["energy"]
+        if model_output.get("forces") is not None:
+            output["forces"] = model_output["forces"]
+        if model_output.get("stress") is not None:
+            output["stress"] = model_output["stress"]
+        return output
+
+    # ------------------------------------------------------------------
+    # forward
+    # ------------------------------------------------------------------
+
+    def forward(self, data: AtomicData | Batch, **kwargs: Any) -> ModelOutputs:
+        """Run TensorNet and return energy, forces, and optionally stress.
+
+        Parameters
+        ----------
+        data : AtomicData | Batch
+            Input data with ``neighbor_list`` and ``neighbor_list_shifts``
+            populated by :class:`~nvalchemi.hooks.NeighborListHook`.
+
+        Returns:
+        -------
+        ModelOutputs
+        """
+        if isinstance(data, AtomicData):
+            data = Batch.from_data_list([data])
+
+        compute_forces = "forces" in (self.model_config.active_outputs & self.model_config.outputs)
+        compute_stresses = "stress" in (self.model_config.active_outputs & self.model_config.outputs)
+
+        # Affine strain for stress (before adapt_input so scaled positions
+        # flow through the model).
+        displacement = None
+        orig_positions = None
+        orig_cell = None
+        if compute_stresses and hasattr(data, "cell") and data.cell is not None:
+            scaled_pos, scaled_cell, displacement = prepare_strain(data.positions, data.cell, data.batch_idx)
+            orig_positions = data.positions
+            orig_cell = data.cell
+            data["positions"] = scaled_pos
+            data["cell"] = scaled_cell
+
+        # Clone + enable grad (avoids mutating the original batch).
+        if compute_forces or compute_stresses:
+            pos = data.positions.clone()
+            pos.requires_grad_(True)
+            data["positions"] = pos
+
+        inputs = self.adapt_input(data, **kwargs)
+
+        g = types.SimpleNamespace(
+            node_type=inputs["node_type"],
+            pos=inputs["pos"],
+            edge_index=inputs["edge_index"],
+            pbc_offshift=inputs["pbc_offshift"],
+            batch=inputs["batch"],
+            num_graphs=inputs["num_graphs"],
+        )
+
+        raw_energy = self.model(g=g)
+        total_energy = self.data_std * raw_energy + self.data_mean
+
+        # ZBL repulsion
+        if self.repuls is not None:
+            from matgl.graph._compute_pyg import compute_pair_vector_and_distance
+
+            _, bond_dist = compute_pair_vector_and_distance(
+                inputs["pos"],
+                inputs["edge_index"],
+                inputs["pbc_offshift"],
+            )
+            g.bond_dist = bond_dist
+            total_energy = total_energy + self.repuls(self.model.element_types, g)
+
+        # Element reference offsets
+        if self._element_ref_offset is not None:
+            atomic_offset = self._element_ref_offset[inputs["node_type"]]
+            graph_offset = torch.zeros(inputs["num_graphs"], device=atomic_offset.device, dtype=atomic_offset.dtype)
+            graph_offset.scatter_add_(0, inputs["batch"], atomic_offset)
+            total_energy = total_energy + graph_offset
+
+        # Reshape to [B, 1]
+        if total_energy.dim() == 0:
+            total_energy = total_energy.unsqueeze(0)
+        if total_energy.dim() == 1:
+            total_energy = total_energy.unsqueeze(-1)
+
+        result: dict[str, torch.Tensor | None] = {"energy": total_energy}
+
+        if compute_forces:
+            result["forces"] = autograd_forces(
+                total_energy,
+                data.positions,
+                training=False,
+                retain_graph=compute_stresses,
+            )
+
+        if compute_stresses and displacement is not None:
+            result["stress"] = autograd_stresses(
+                total_energy,
+                displacement,
+                orig_cell,
+                data.num_graphs,
+            )
+
+        # Restore originals after strain
+        if orig_positions is not None:
+            data["positions"] = orig_positions
+            data["cell"] = orig_cell
+
+        return self.adapt_output(result, data)
+
+    # ------------------------------------------------------------------
+    # compute_embeddings
+    # ------------------------------------------------------------------
+
+    def compute_embeddings(self, data: AtomicData | Batch, **kwargs: Any) -> AtomicData | Batch:
+        """Compute node and graph embeddings (no forces/stress).
+
+        Writes ``node_embeddings`` ([V, units]) and ``graph_embeddings``
+        ([B, units]) into *data* in-place.
+        """
+        if isinstance(data, AtomicData):
+            data = Batch.from_data_list([data])
+
+        inputs = self.adapt_input(data, **kwargs)
+        g = types.SimpleNamespace(
+            node_type=inputs["node_type"],
+            pos=inputs["pos"],
+            edge_index=inputs["edge_index"],
+            pbc_offshift=inputs["pbc_offshift"],
+            batch=inputs["batch"],
+            num_graphs=inputs["num_graphs"],
+        )
+
+        fea_dict = self.model(g=g, return_all_layer_output=True)
+        node_embeddings = fea_dict["readout"]  # [V, units]
+
+        units = node_embeddings.shape[-1]
+        graph_embeddings = torch.zeros(
+            inputs["num_graphs"],
+            units,
+            device=node_embeddings.device,
+            dtype=node_embeddings.dtype,
+        )
+        graph_embeddings.scatter_add_(
+            0,
+            inputs["batch"].unsqueeze(-1).expand(-1, units),
+            node_embeddings,
+        )
+
+        data.node_embeddings = node_embeddings
+        data.graph_embeddings = graph_embeddings
+        return data
+
+    # ------------------------------------------------------------------
+    # export_model
+    # ------------------------------------------------------------------
+
+    def export_model(self, path: Path, as_state_dict: bool = False) -> None:
+        """Save the underlying TensorNet (without the nvalchemi wrapper).
+
+        Not compatible with ``matgl.load_model``.  To get that format,
+        save the original ``Potential`` before wrapping.
+        """
+        if as_state_dict:
+            torch.save(self.model.state_dict(), path)
+        else:
+            torch.save(self.model, path)

--- a/src/matgl/ext/_tensornet_alchmtk.py
+++ b/src/matgl/ext/_tensornet_alchmtk.py
@@ -174,6 +174,8 @@ class TensorNetWrapper(nn.Module, BaseModelMixin):  # type: ignore[misc]
             data_mean = torch.tensor(data_mean, dtype=torch.float32)
         if not isinstance(data_std, torch.Tensor):
             data_std = torch.tensor(data_std, dtype=torch.float32)
+        self.data_mean: torch.Tensor
+        self.data_std: torch.Tensor
         self.register_buffer("data_mean", data_mean)
         self.register_buffer("data_std", data_std)
 
@@ -193,6 +195,7 @@ class TensorNetWrapper(nn.Module, BaseModelMixin):  # type: ignore[misc]
         table = torch.full((max_z + 1,), -1, dtype=torch.long)
         for sym, idx in symbol_to_idx.items():
             table[Element(sym).Z] = idx
+        self._z_to_type: torch.Tensor
         self.register_buffer("_z_to_type", table, persistent=False)
 
     # ------------------------------------------------------------------
@@ -221,8 +224,8 @@ class TensorNetWrapper(nn.Module, BaseModelMixin):  # type: ignore[misc]
 
         return cls(
             model=potential.model,
-            data_mean=potential.data_mean.clone(),  # type: ignore[operator]
-            data_std=potential.data_std.clone(),  # type: ignore[operator]
+            data_mean=potential.data_mean.clone(),
+            data_std=potential.data_std.clone(),
             element_refs=element_refs,
             calc_repuls=getattr(potential, "calc_repuls", False),
         )
@@ -276,7 +279,7 @@ class TensorNetWrapper(nn.Module, BaseModelMixin):  # type: ignore[misc]
         device = data.positions.device
         B: int = data.num_graphs
 
-        node_type = self._z_to_type[data.atomic_numbers]  # type: ignore[index]
+        node_type = self._z_to_type[data.atomic_numbers]
 
         # nvalchemi (E, 2) -> TensorNet/PyG (2, E)
         edge_index = data.neighbor_list.T  # [2, E]

--- a/src/matgl/ext/_tensornet_alchmtk.py
+++ b/src/matgl/ext/_tensornet_alchmtk.py
@@ -222,10 +222,14 @@ class TensorNetWrapper(nn.Module, BaseModelMixin):  # type: ignore[misc]
         if potential.element_refs is not None:
             element_refs = potential.element_refs.property_offset.clone()
 
+        data_mean = potential.data_mean
+        data_std = potential.data_std
+        assert isinstance(data_mean, torch.Tensor)
+        assert isinstance(data_std, torch.Tensor)
         return cls(
             model=potential.model,
-            data_mean=potential.data_mean.clone(),
-            data_std=potential.data_std.clone(),
+            data_mean=data_mean.clone(),
+            data_std=data_std.clone(),
             element_refs=element_refs,
             calc_repuls=getattr(potential, "calc_repuls", False),
         )

--- a/src/matgl/ext/alchmtk.py
+++ b/src/matgl/ext/alchmtk.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""nvalchemi-toolkit interface for MatGL."""
+
+from __future__ import annotations
+
+from ._tensornet_alchmtk import TensorNetWrapper
+
+__all__ = ["TensorNetWrapper"]

--- a/tests/ext/test_tensornet_alchmtk.py
+++ b/tests/ext/test_tensornet_alchmtk.py
@@ -1,0 +1,586 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Tests for TensorNetWrapper (nvalchemi-toolkit integration)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import matgl
+
+if matgl.config.BACKEND != "PYG":
+    pytest.skip("Skipping PYG tests", allow_module_level=True)
+
+pytest.importorskip("nvalchemi", reason="nvalchemi-toolkit required for alchmtk tests")
+
+import numpy as np
+from nvalchemi.data import AtomicData, Batch
+from nvalchemi.dynamics.base import DynamicsStage
+from nvalchemi.hooks import HookContext, NeighborListHook
+from pymatgen.core import Element
+
+from matgl.apps._pes_pyg import Potential
+from matgl.ext.alchmtk import TensorNetWrapper
+from matgl.graph._compute_pyg import compute_pair_vector_and_distance
+from matgl.models._tensornet_pyg import TensorNet
+
+# 1 eV/A^3 = 160.21766208 GPa
+EV_A3_TO_GPA = 160.21766208
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def model_tensornet():
+    """Same convention as test_pes_pyg — small TensorNet for MoS."""
+    return TensorNet(
+        element_types=("Mo", "S"),
+        is_intensive=False,
+        units=64,
+        use_smooth=True,
+        max_n=5,
+        rbf_type="SphericalBessel",
+        use_warp=False,
+    )
+
+
+@pytest.fixture
+def model_tensornet_ch4():
+    """Small TensorNet for CH4 molecule tests."""
+    return TensorNet(
+        element_types=("C", "H"),
+        is_intensive=False,
+        units=32,
+        nblocks=1,
+        cutoff=2.0,
+        use_warp=False,
+    )
+
+
+@pytest.fixture
+def potential_ch4(model_tensornet_ch4):
+    return Potential(
+        model=model_tensornet_ch4,
+        data_mean=torch.tensor(0.0),
+        data_std=torch.tensor(1.0),
+        calc_forces=True,
+        calc_stresses=False,
+    )
+
+
+@pytest.fixture
+def potential(model_tensornet):
+    return Potential(
+        model=model_tensornet,
+        data_mean=torch.tensor(0.0),
+        data_std=torch.tensor(1.0),
+        calc_forces=True,
+        calc_stresses=True,
+    )
+
+
+@pytest.fixture
+def potential_with_refs(model_tensornet):
+    refs = torch.tensor([-1.5, -2.3], dtype=torch.float32)  # Mo, S
+    return Potential(
+        model=model_tensornet,
+        data_mean=torch.tensor(0.0),
+        data_std=torch.tensor(1.0),
+        element_refs=refs,
+        calc_forces=True,
+        calc_stresses=True,
+    )
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _matgl_graph_to_atomic_data(graph, lattice, element_types, is_periodic=True):
+    """Convert a matgl PyG graph into nvalchemi AtomicData.
+
+    Uses the exact same neighbor_list and pbc_offset from the matgl graph
+    so any numerical difference is from the wrapper, not the neighbor list.
+    """
+    atomic_numbers = torch.tensor(
+        [Element(element_types[t]).Z for t in graph.node_type.tolist()],
+        dtype=torch.int64,
+    )
+    lat = lattice[0] if lattice.dim() == 3 else lattice
+    positions = graph.frac_coords @ lat
+
+    kwargs = {
+        "atomic_numbers": atomic_numbers,
+        "positions": positions,
+        "neighbor_list": graph.edge_index.long().T,  # matgl [2, E] -> nvalchemi [E, 2]
+        "neighbor_list_shifts": graph.pbc_offset.float(),
+    }
+    if is_periodic:
+        kwargs["cell"] = lat.unsqueeze(0)
+        kwargs["pbc"] = torch.tensor([[True, True, True]])
+
+    return AtomicData(**kwargs)
+
+
+def _set_active_outputs(wrapper, outputs):
+    """Set active outputs on wrapper's model_config."""
+    wrapper.model_config.active_outputs = set(outputs)
+
+
+def _run_nl_hook(wrapper, batch):
+    """Run NeighborListHook on a batch using HookContext."""
+    nl_hook = NeighborListHook(
+        wrapper.model_config.neighbor_config,
+        stage=DynamicsStage.BEFORE_COMPUTE,
+    )
+    ctx = HookContext(batch=batch, step_count=0)
+    nl_hook(ctx, DynamicsStage.BEFORE_COMPUTE)
+
+
+# ------------------------------------------------------------------
+# Construction validation
+# ------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_is_intensive_rejected(self):
+        model = TensorNet(
+            element_types=("Mo", "S"),
+            is_intensive=True,
+            units=32,
+            nblocks=1,
+            use_warp=False,
+        )
+        with pytest.raises(ValueError, match="is_intensive=False"):
+            TensorNetWrapper(model=model)
+
+    def test_from_potential(self, potential):
+        wrapper = TensorNetWrapper.from_potential(potential)
+        assert wrapper.model is potential.model
+        assert torch.equal(wrapper.data_mean, potential.data_mean)
+        assert torch.equal(wrapper.data_std, potential.data_std)
+
+    def test_from_potential_wrong_model_type(self):
+        dummy = Potential(model=torch.nn.Linear(10, 1), calc_forces=False, calc_stresses=False)
+        with pytest.raises(TypeError, match="TensorNet"):
+            TensorNetWrapper.from_potential(dummy)
+
+    def test_from_potential_with_zbl(self):
+        model = TensorNet(
+            element_types=("Mo", "S"),
+            is_intensive=False,
+            units=32,
+            nblocks=1,
+            use_warp=False,
+        )
+        pot = Potential(model=model, calc_repuls=True)
+        wrapper = TensorNetWrapper.from_potential(pot)
+        assert wrapper.repuls is not None
+
+    def test_from_potential_with_element_refs(self, potential_with_refs):
+        wrapper = TensorNetWrapper.from_potential(potential_with_refs)
+        assert wrapper._element_ref_offset is not None
+        assert torch.equal(
+            wrapper._element_ref_offset,
+            potential_with_refs.element_refs.property_offset,
+        )
+
+    def test_model_config(self, potential):
+        wrapper = TensorNetWrapper.from_potential(potential)
+        cfg = wrapper.model_config
+        assert "energy" in cfg.outputs
+        assert "forces" in cfg.outputs
+        assert "stress" in cfg.outputs
+        assert "forces" in cfg.autograd_outputs
+        assert "stress" in cfg.autograd_outputs
+        assert cfg.supports_pbc is True
+        assert cfg.needs_pbc is False
+        assert cfg.neighbor_config is not None
+        assert cfg.neighbor_config.cutoff == potential.model.cutoff
+
+    def test_embedding_shapes(self, potential):
+        wrapper = TensorNetWrapper.from_potential(potential)
+        shapes = wrapper.embedding_shapes
+        assert shapes["node_embeddings"] == (64,)
+        assert shapes["graph_embeddings"] == (64,)
+
+
+# ------------------------------------------------------------------
+# Neighbor list consistency
+# ------------------------------------------------------------------
+
+
+class TestNeighborListConsistency:
+    def test_same_edges(self, graph_MoS_pyg):
+        """AtomicData uses the exact same edges as the matgl graph."""
+        structure, graph, _ = graph_MoS_pyg
+        element_types = ("Mo", "S")
+        lat = torch.tensor(structure.lattice.matrix, dtype=matgl.float_th)
+
+        data = _matgl_graph_to_atomic_data(graph, lat.unsqueeze(0), element_types)
+        batch = Batch.from_data_list([data])
+
+        # Batch stores [E, 2]; matgl stores [2, E]. Transpose to compare.
+        assert torch.equal(batch.neighbor_list.T.long(), graph.edge_index.long())
+
+    def test_same_shifts(self, graph_MoS_pyg):
+        """neighbor_list_shifts match pbc_offset from matgl graph."""
+        structure, graph, _ = graph_MoS_pyg
+        element_types = ("Mo", "S")
+        lat = torch.tensor(structure.lattice.matrix, dtype=matgl.float_th)
+
+        data = _matgl_graph_to_atomic_data(graph, lat.unsqueeze(0), element_types)
+        batch = Batch.from_data_list([data])
+
+        assert torch.allclose(batch.neighbor_list_shifts.float(), graph.pbc_offset.float(), atol=1e-6)
+
+
+# ------------------------------------------------------------------
+# Numerical correctness: periodic crystal (MoS from conftest)
+# ------------------------------------------------------------------
+
+
+class TestNumericalCorrectnessPeriodic:
+    def test_energy_matches(self, potential, graph_MoS_pyg):
+        structure, graph, state = graph_MoS_pyg
+        lat = torch.tensor(structure.lattice.matrix, dtype=matgl.float_th)
+
+        e_matgl, _, _, _ = potential(graph, lat, state)
+
+        wrapper = TensorNetWrapper.from_potential(potential)
+        _set_active_outputs(wrapper, {"energy"})
+        data = _matgl_graph_to_atomic_data(graph, lat.unsqueeze(0), ("Mo", "S"))
+        outputs = wrapper(Batch.from_data_list([data]))
+
+        assert torch.allclose(outputs["energy"].squeeze(), e_matgl.squeeze(), atol=1e-5)
+
+    def test_forces_match(self, potential, graph_MoS_pyg):
+        structure, graph, state = graph_MoS_pyg
+        lat = torch.tensor(structure.lattice.matrix, dtype=matgl.float_th)
+
+        _, f_matgl, _, _ = potential(graph, lat, state)
+
+        wrapper = TensorNetWrapper.from_potential(potential)
+        _set_active_outputs(wrapper, {"energy", "forces"})
+        data = _matgl_graph_to_atomic_data(graph, lat.unsqueeze(0), ("Mo", "S"))
+        outputs = wrapper(Batch.from_data_list([data]))
+
+        assert torch.allclose(outputs["forces"], f_matgl, atol=1e-5)
+
+    def test_stresses_match(self, potential, graph_MoS_pyg):
+        structure, graph, state = graph_MoS_pyg
+        lat = torch.tensor(structure.lattice.matrix, dtype=matgl.float_th)
+
+        _, _, s_matgl, _ = potential(graph, lat, state)
+
+        wrapper = TensorNetWrapper.from_potential(potential)
+        _set_active_outputs(wrapper, {"energy", "forces", "stress"})
+        data = _matgl_graph_to_atomic_data(graph, lat.unsqueeze(0), ("Mo", "S"))
+        outputs = wrapper(Batch.from_data_list([data]))
+
+        # wrapper: Cauchy convention -dE/d(strain)/V in eV/A^3
+        # matgl: +dE/d(strain)/V * 160.2 in GPa
+        # So: -wrapper_stress * GPa_factor == matgl_stress
+        s_wrapper_gpa = -outputs["stress"].squeeze() * EV_A3_TO_GPA
+        assert torch.allclose(s_wrapper_gpa, s_matgl.squeeze(), atol=1e-4)
+
+
+# ------------------------------------------------------------------
+# Numerical correctness: molecule (CH4 from conftest)
+# ------------------------------------------------------------------
+
+
+class TestNumericalCorrectnessMolecule:
+    def test_molecule_energy_matches(self, potential_ch4, graph_CH4_pyg):
+        """Non-periodic CH4: energy and forces match matgl Potential."""
+        _, graph, state = graph_CH4_pyg
+        element_types = ("C", "H")
+
+        # matgl path — identity lattice for molecules
+        lat = torch.eye(3, dtype=matgl.float_th)
+        e_matgl, f_matgl, _, _ = potential_ch4(graph, lat, state)
+
+        # wrapper path
+        wrapper = TensorNetWrapper.from_potential(potential_ch4)
+        _set_active_outputs(wrapper, {"energy", "forces"})
+
+        atomic_numbers = torch.tensor(
+            [Element(element_types[t]).Z for t in graph.node_type.tolist()],
+            dtype=torch.int64,
+        )
+        positions = graph.frac_coords.float()
+
+        data = AtomicData(
+            atomic_numbers=atomic_numbers,
+            positions=positions,
+            neighbor_list=graph.edge_index.long().T,
+            neighbor_list_shifts=graph.pbc_offset.float(),
+        )
+        outputs = wrapper(Batch.from_data_list([data]))
+
+        assert torch.allclose(outputs["energy"].squeeze(), e_matgl.squeeze(), atol=1e-5)
+        assert torch.allclose(outputs["forces"], f_matgl, atol=1e-5)
+
+
+# ------------------------------------------------------------------
+# Element refs
+# ------------------------------------------------------------------
+
+
+class TestElementRefs:
+    def test_energy_offset(self, potential, potential_with_refs, graph_MoS_pyg):
+        """element_refs shifts energy by the expected per-element sum."""
+        structure, graph, _ = graph_MoS_pyg
+        lat = torch.tensor(structure.lattice.matrix, dtype=matgl.float_th)
+
+        wrapper_no = TensorNetWrapper.from_potential(potential)
+        _set_active_outputs(wrapper_no, {"energy"})
+
+        wrapper_yes = TensorNetWrapper.from_potential(potential_with_refs)
+        _set_active_outputs(wrapper_yes, {"energy"})
+
+        data = _matgl_graph_to_atomic_data(graph, lat.unsqueeze(0), ("Mo", "S"))
+        batch = Batch.from_data_list([data])
+
+        e_no = wrapper_no(batch)["energy"]
+        e_yes = wrapper_yes(batch)["energy"]
+
+        # MoS: 1 Mo (ref=-1.5) + 1 S (ref=-2.3) = -3.8
+        expected_offset = -1.5 + -2.3
+        assert pytest.approx((e_yes - e_no).item(), abs=1e-5) == expected_offset
+
+    def test_forces_unchanged(self, potential, potential_with_refs, graph_MoS_pyg):
+        """element_refs are position-independent, so forces are identical."""
+        structure, graph, _ = graph_MoS_pyg
+        lat = torch.tensor(structure.lattice.matrix, dtype=matgl.float_th)
+
+        wrapper_no = TensorNetWrapper.from_potential(potential)
+        _set_active_outputs(wrapper_no, {"energy", "forces"})
+
+        wrapper_yes = TensorNetWrapper.from_potential(potential_with_refs)
+        _set_active_outputs(wrapper_yes, {"energy", "forces"})
+
+        data = _matgl_graph_to_atomic_data(graph, lat.unsqueeze(0), ("Mo", "S"))
+        batch = Batch.from_data_list([data])
+
+        f_no = wrapper_no(batch)["forces"]
+        f_yes = wrapper_yes(batch)["forces"]
+
+        assert torch.allclose(f_no, f_yes, atol=1e-6)
+
+
+# ------------------------------------------------------------------
+# ZBL nuclear repulsion
+# ------------------------------------------------------------------
+
+
+class TestZBL:
+    def test_zbl_adds_repulsive_energy(self, model_tensornet, graph_MoS_pyg):
+        """ZBL adds a positive repulsive energy contribution."""
+        structure, graph, _ = graph_MoS_pyg
+        lat = torch.tensor(structure.lattice.matrix, dtype=matgl.float_th)
+
+        wrapper_no_zbl = TensorNetWrapper(model=model_tensornet)
+        _set_active_outputs(wrapper_no_zbl, {"energy"})
+
+        wrapper_with_zbl = TensorNetWrapper(model=model_tensornet, calc_repuls=True)
+        _set_active_outputs(wrapper_with_zbl, {"energy"})
+
+        data = _matgl_graph_to_atomic_data(graph, lat.unsqueeze(0), ("Mo", "S"))
+        batch = Batch.from_data_list([data])
+
+        e_no = wrapper_no_zbl(batch)["energy"]
+        e_yes = wrapper_with_zbl(batch)["energy"]
+
+        # ZBL is purely repulsive — adds positive energy
+        assert (e_yes - e_no).item() > 0
+
+    def test_zbl_matches_matgl(self, model_tensornet, graph_MoS_pyg):
+        """ZBL energy matches matgl Potential with calc_repuls=True."""
+        structure, graph, state = graph_MoS_pyg
+        lat = torch.tensor(structure.lattice.matrix, dtype=matgl.float_th)
+
+        pot = Potential(
+            model=model_tensornet,
+            calc_repuls=True,
+            calc_forces=False,
+            calc_stresses=False,
+        )
+        e_matgl, _, _, _ = pot(graph, lat, state)
+
+        wrapper = TensorNetWrapper.from_potential(pot)
+        _set_active_outputs(wrapper, {"energy"})
+        data = _matgl_graph_to_atomic_data(graph, lat.unsqueeze(0), ("Mo", "S"))
+        outputs = wrapper(Batch.from_data_list([data]))
+
+        assert torch.allclose(outputs["energy"].squeeze(), e_matgl.squeeze(), atol=1e-5)
+
+
+# ------------------------------------------------------------------
+# End-to-end: neighbor list built independently by both paths
+# ------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    def test_neighborlist_distances_match(self, potential, MoS):
+        """NeighborListHook and matgl's Structure2Graph produce the same
+        pairwise distances (order may differ)."""
+        from matgl.ext._pymatgen_pyg import Structure2Graph
+
+        cutoff = float(potential.model.cutoff)
+        element_types = ("Mo", "S")
+
+        # matgl path: Structure2Graph -> compute distances
+        converter = Structure2Graph(element_types=element_types, cutoff=cutoff)
+        graph, lattice, _ = converter.get_graph(MoS)
+        graph.pbc_offshift = torch.matmul(graph.pbc_offset, lattice[0])
+        graph.pos = graph.frac_coords @ lattice[0]
+        _, dist_matgl = compute_pair_vector_and_distance(
+            graph.pos,
+            graph.edge_index,
+            graph.pbc_offshift,
+        )
+
+        # nvalchemi path: AtomicData -> NeighborListHook -> compute distances
+        wrapper = TensorNetWrapper.from_potential(potential)
+        atomic_numbers = torch.tensor(
+            [Element(element_types[t]).Z for t in graph.node_type.tolist()],
+            dtype=torch.int64,
+        )
+        positions = (graph.frac_coords @ lattice[0]).float()
+        cell = lattice[0].float().unsqueeze(0)
+
+        data = AtomicData(
+            atomic_numbers=atomic_numbers,
+            positions=positions,
+            cell=cell,
+            pbc=torch.tensor([[True, True, True]]),
+        )
+        batch = Batch.from_data_list([data])
+
+        _run_nl_hook(wrapper, batch)
+
+        # Compute distances from nvalchemi's neighbor list
+        inputs = wrapper.adapt_input(batch)
+        _, dist_nval = compute_pair_vector_and_distance(
+            inputs["pos"],
+            inputs["edge_index"],
+            inputs["pbc_offshift"],
+        )
+
+        # Same set of distances (order may differ)
+        np.testing.assert_array_almost_equal(
+            np.sort(dist_matgl.detach().cpu().numpy()),
+            np.sort(dist_nval.detach().cpu().numpy()),
+            decimal=4,
+        )
+
+    def test_energy_forces_end_to_end(self, potential, MoS):
+        """Full pipeline: AtomicData.from_structure -> NeighborListHook -> wrapper
+        vs matgl's Potential. Energies and forces should match."""
+        from matgl.ext._pymatgen_pyg import Structure2Graph
+
+        cutoff = float(potential.model.cutoff)
+        element_types = ("Mo", "S")
+
+        # matgl path
+        converter = Structure2Graph(element_types=element_types, cutoff=cutoff)
+        graph, _, state = converter.get_graph(MoS)
+        lat = torch.tensor(MoS.lattice.matrix, dtype=matgl.float_th)
+        e_matgl, f_matgl, _, _ = potential(graph, lat, state)
+
+        # nvalchemi path
+        wrapper = TensorNetWrapper.from_potential(potential)
+        _set_active_outputs(wrapper, {"energy", "forces"})
+
+        data = AtomicData.from_structure(MoS)
+        batch = Batch.from_data_list([data])
+
+        _run_nl_hook(wrapper, batch)
+
+        outputs = wrapper(batch)
+
+        assert torch.allclose(
+            outputs["energy"].squeeze(),
+            e_matgl.squeeze(),
+            atol=1e-4,
+        )
+        assert torch.allclose(outputs["forces"], f_matgl, atol=1e-4)
+
+
+# ------------------------------------------------------------------
+# Pretrained model: TensorNet-MatPES-PBE-v2025.1-PES
+# ------------------------------------------------------------------
+
+
+class TestPretrained:
+    def test_pretrained_MoS_energy(self, MoS):
+        """Pretrained TensorNet on MoS with NL built via NeighborListHook."""
+        pot = matgl.load_model("pretrained_models/TensorNet-MatPES-PBE-v2025.1-PES/")
+        wrapper = TensorNetWrapper.from_potential(pot)
+        _set_active_outputs(wrapper, {"energy", "forces"})
+
+        data = AtomicData.from_structure(MoS)
+        batch = Batch.from_data_list([data])
+
+        _run_nl_hook(wrapper, batch)
+
+        outputs = wrapper(batch)
+
+        # Reference from test_ase_pyg.py: -10.4884214
+        assert outputs["energy"].squeeze().item() == pytest.approx(
+            -10.4884214,
+            abs=1e-3,
+        )
+        assert outputs["forces"].shape == (2, 3)
+
+    def test_pretrained_molecule_energy(self, AcAla3NHMe):
+        """Pretrained TensorNet on AcAla3NHMe molecule with NL built via NeighborListHook."""
+        pot = matgl.load_model("pretrained_models/TensorNet-MatPES-PBE-v2025.1-PES/")
+        wrapper = TensorNetWrapper.from_potential(pot)
+        _set_active_outputs(wrapper, {"energy", "forces"})
+
+        data = AtomicData.from_structure(AcAla3NHMe)
+        batch = Batch.from_data_list([data])
+
+        _run_nl_hook(wrapper, batch)
+
+        outputs = wrapper(batch)
+
+        # Reference from test_ase_pyg.py: -247.286789
+        assert outputs["energy"].squeeze().item() == pytest.approx(
+            -247.286789,
+            abs=1e-3,
+        )
+        assert outputs["forces"].shape == (42, 3)


### PR DESCRIPTION
## Summary

Adds `TensorNetWrapper` that bridges MatGL's `TensorNet` (`PyG` backend) with NVIDIA's `nvalchemi-toolkit`, enabling fully GPU-resident molecular dynamics, geometry relaxation and more. 

Major changes:

- `matgl.ext.alchmtk.TensorNetWrapper` — wraps a matgl `Potential` into nvalchemi's `BaseModelMixin` interface. 
- Supports energy, forces, stresses (via `autograd`), element refs, and ZBL repulsion
- `from_potential()` factory for easy loading from pretrained models
- `nvalchemi` as optional dependency (pip install matgl[alchmtk])
- 21 tests including numerical correctness against matgl's `Potential`, pretrained model validation, and end-to-end with `NeighborListHook`
- NVT Langevin MD example with pretrained `TensorNet` on LiFePO4

## Todos

If this is work in progress, what else needs to be done?

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```