### PR TITLE
[WIP] Message aggregation direction issue that causes incorrect energies in layered structures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 ]
 dependencies = [
     "ase",
-    "torch",  
+    "torch",
     "torchdata",
     "lightning<=2.6.1",
     "pydantic",

--- a/src/matgl/layers/_graph_convolution_pyg.py
+++ b/src/matgl/layers/_graph_convolution_pyg.py
@@ -113,7 +113,7 @@ class TensorNetInteraction(nn.Module):
         x_S = traceless_tensors
 
         messages = self.message(edge_index, x_I, x_A, x_S, edge_attr_processed)
-        Im, Am, Sm = self.aggregate(messages, edge_index[0], X.size(0))
+        Im, Am, Sm = self.aggregate(messages, edge_index[1], X.size(0))
         # Combine messages
         msg = Im + Am + Sm
 


### PR DESCRIPTION
## Summary

Major changes: Fixes a bug in the PyG `TensorNetInteraction` layer where messages are aggregated into the wrong set of nodes, causing incorrect energies for asymmetric/layered structures.

This is inconsistent with the DGL implementation, which correctly aggregates into `dst` nodes via `update_all(fn.copy_e, fn.sum)`, and inconsistent with `TensorEmbedding` (line 176) which already correctly uses `edge_index[1]`.

### Fix
Change line 116 in `_graph_convolution_pyg.py` from:
```python
Im, Am, Sm = self.aggregate(messages, edge_index[0], X.size(0))
```
to:
```python
Im, Am, Sm = self.aggregate(messages, edge_index[1], X.size(0))
```
## Todos

retrain the potential

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
